### PR TITLE
add python/django support to ci and evaluator

### DIFF
--- a/services/pr-evaluator/prompts/evaluation.md
+++ b/services/pr-evaluator/prompts/evaluation.md
@@ -42,19 +42,31 @@ Check for:
 - Build configuration is valid
 
 ### 3. PostHog implementation (score 1-5)
+
 Check for:
-- `posthog-js` or `posthog-node` in dependencies
-- Correct initialization patterns by framework
+
+- PostHog SDK in dependencies:
+  - JavaScript: `posthog-js` or `posthog-node` in package.json
+  - Python: `posthog` in requirements.txt or pyproject.toml
+  - Other: appropriate SDK for the language/framework
+- Correct initialization patterns by framework:
+  - JavaScript: Provider component or singleton client module
+  - Django: `AppConfig.ready()` in apps.py
+  - Other: SDK initialized at app startup
 - Correct API host configuration
-- PostHog initialization with API key
+- PostHog initialization with API key (via environment variable, not hardcoded)
 - Captures baseline events (pageviews, screen views, custom events)
 - `posthog.capture()` calls for user actions
 - Page view tracking setup
-- User identification (`posthog.identify()`)
+- User identification:
+  - JavaScript: `posthog.identify()`
+  - Python: `identify_context()` within `new_context()` blocks
 - Error tracking setup (exception capture)
 - No PII in event properties
 - Proper cleanup on unmount (React)
 - Reverse proxy that circumvents adblock issues when sending events to PostHog
+
+**Note:** Python SDK v7+ uses a context-based API. Do not flag `new_context()`, `capture()`, `tag()` patterns as errors.
 
 ### 4. Quality of PostHog insights and events (score 1-5)
 Check for:

--- a/services/wizard-ci/utils.ts
+++ b/services/wizard-ci/utils.ts
@@ -79,14 +79,25 @@ export function findApps(appsDir: string): App[] {
     if (!existsSync(dir)) return;
 
     for (const entry of readdirSync(dir, { withFileTypes: true })) {
-      if (!entry.isDirectory() || entry.name.startsWith(".") || entry.name === "node_modules") {
+      // Skip hidden entries and node_modules
+      if (entry.name.startsWith(".") || entry.name === "node_modules") {
+        continue;
+      }
+
+      // Handle both directories and symlinks to directories
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) {
         continue;
       }
 
       const fullPath = join(dir, entry.name);
       const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name;
 
-      if (existsSync(join(fullPath, "package.json"))) {
+      // Check for JS/TS projects (package.json) or Python projects (manage.py for Django, requirements.txt)
+      const isJsProject = existsSync(join(fullPath, "package.json"));
+      const isDjangoProject = existsSync(join(fullPath, "manage.py"));
+      const isPythonProject = existsSync(join(fullPath, "requirements.txt")) || existsSync(join(fullPath, "pyproject.toml"));
+
+      if (isJsProject || isDjangoProject || isPythonProject) {
         apps.push({ name: relativePath, path: fullPath });
       } else {
         scan(fullPath, relativePath);


### PR DESCRIPTION
- extends ci app detection to recognize python/django projects using `manage.py`, `requirements.txt`, and `pyproject.toml`
- updates PR eval prompt with python SDK paterns + Django criteria 💪 
