### PR TITLE
chore: environment var cleanup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,4 +9,6 @@ WIZARD_PATH=~/development/wizard
 POSTHOG_PERSONAL_API_KEY=phx_...
 # POSTHOG_REGION is optional, defaults to 'us'. Can also be passed via --region flag or workflow input.
 # POSTHOG_REGION=us
+# Optional wizard log output directory. Wizard writes posthog-wizard.log inside this directory.
+# POSTHOG_WIZARD_LOG_DIR=/tmp
 POSTHOG_WIZARD_PROJECT_ID=123

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ cp .env.example .env
 | `WIZARD_PATH` | Yes | Path to your local wizard repo (e.g., `~/development/wizard`) |
 | `POSTHOG_PERSONAL_API_KEY` | For CI | PostHog personal API key for wizard CI mode and PR evaluator |
 | `POSTHOG_REGION` | No | PostHog region (`us` or `eu`). Defaults to `us`. Can also be set via `--region` flag or workflow input. |
+| `POSTHOG_WIZARD_LOG_DIR` | No | Directory for wizard verbose logs. Wizard writes `posthog-wizard.log` inside this directory (defaults to `/tmp`). |
 
 Make sure you've set up and installed dependencies for all required repos.
 
@@ -108,7 +109,7 @@ Use keyboard shortcuts in mprocs: `s` to start, `x` to stop, `r` to restart, `q`
 | Process | Description |
 |---------|-------------|
 | `wizard-run` | Interactive app selector - choose which app to run wizard on |
-| `wizard-tail-run` | Tail the wizard's verbose output (`/tmp/posthog-wizard.log`) |
+| `wizard-tail-run` | Tail the wizard's verbose output (`$POSTHOG_WIZARD_LOG_DIR/posthog-wizard.log`, defaults to `/tmp/posthog-wizard.log`) |
 | `wizard-ci-run` | Full CI flow: run wizard, create PR, evaluate |
 | `wizard-ci-local-run` | CI flow with local evaluation (no PR) |
 | `wizard-ci-create-pr` | Push branch and create PR only (skip wizard run) |

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -56,8 +56,9 @@ procs:
 
   wizard-tail-run:
     # Tail the wizard's verbose output
-    shell: "tail -f /tmp/posthog-wizard.log"
+    shell: "tail -f \"${POSTHOG_WIZARD_LOG_DIR:-/tmp}/posthog-wizard.log\""
     autostart: false
+    env_file: .env
 
   # ═══════════════════════════════════════════════════════════════════════════
   # WIZARD BENCHMARK - Run wizard with benchmark tracking

--- a/services/wizard-benchmark/index.ts
+++ b/services/wizard-benchmark/index.ts
@@ -48,12 +48,13 @@ const PLUGIN_NAMES = [
 ] as const;
 
 function defaultConfig(): BenchmarkConfig {
+  const logDir = process.env.POSTHOG_WIZARD_LOG_DIR || "/tmp";
   return {
     plugins: Object.fromEntries(PLUGIN_NAMES.map((p) => [p, true])),
     output: {
       benchmarkPath: "/tmp/posthog-wizard-benchmark.json",
       benchmarkEnabled: true,
-      logPath: "/tmp/posthog-wizard.log",
+      logPath: join(logDir, "posthog-wizard.log"),
       logEnabled: true,
       suppressWizardLogs: false,
     },


### PR DESCRIPTION
Some clean up because we had duplicate env vars following https://github.com/PostHog/wizard/pull/348