### PR TITLE
chore(devex): Replace mprocs with phrocs

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -574,17 +574,6 @@ jobs:
             echo "::warning::MCP server failed to start after 2 minutes"
           fi
 
-          # Run wizard-ci (always runs in CI mode internally)
-          cd $GITHUB_WORKSPACE
-          CMD="pnpm wizard-ci --app ${{ matrix.app }} --base ${{ needs.discover.outputs.input_base_branch }}"
-          if [ -n "${{ needs.discover.outputs.trigger_id }}" ]; then
-            CMD="$CMD --trigger-id ${{ needs.discover.outputs.trigger_id }}"
-          fi
-          if [ "${{ needs.discover.outputs.input_evaluate }}" = "true" ]; then
-            CMD="$CMD --evaluate"
-          fi
-
-          echo "cmd=$CMD" >> $GITHUB_OUTPUT
           echo "mcp_pid=$MCP_PID" >> $GITHUB_OUTPUT
           echo "context_mill_pid=$CONTEXT_MILL_PID" >> $GITHUB_OUTPUT
         env:
@@ -611,8 +600,19 @@ jobs:
         id: execute-wizard
         continue-on-error: true
         run: |
-          ${{ steps.run-wizard.outputs.cmd }} 2>&1 | tee wizard-output.log
+          CMD_ARGS=(pnpm wizard-ci --app "$MATRIX_APP" --base "$INPUT_BASE_BRANCH")
+          if [ -n "$TRIGGER_ID" ]; then
+            CMD_ARGS+=(--trigger-id "$TRIGGER_ID")
+          fi
+          if [ "$INPUT_EVALUATE" = "true" ]; then
+            CMD_ARGS+=(--evaluate)
+          fi
+          "${CMD_ARGS[@]}" 2>&1 | tee wizard-output.log
         env:
+          MATRIX_APP: ${{ matrix.app }}
+          INPUT_BASE_BRANCH: ${{ needs.discover.outputs.input_base_branch }}
+          TRIGGER_ID: ${{ needs.discover.outputs.trigger_id }}
+          INPUT_EVALUATE: ${{ needs.discover.outputs.input_evaluate }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           POSTHOG_REGION: ${{ needs.discover.outputs.input_posthog_region }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
@@ -630,8 +630,8 @@ jobs:
         id: process-results
         if: always()
         run: |
-          if [ "${{ steps.execute-wizard.outcome }}" != "success" ]; then
-            echo "::warning::Wizard exited with failure for ${{ matrix.app }}"
+          if [ "$WIZARD_OUTCOME" != "success" ]; then
+            echo "::warning::Wizard exited with failure for $MATRIX_APP"
           fi
 
           # Save resources zips from running server (for artifact upload)
@@ -639,8 +639,8 @@ jobs:
           curl -s http://localhost:8765/skills-mcp-resources.zip -o skills-mcp-resources.zip || true
 
           # Stop servers
-          kill ${{ steps.run-wizard.outputs.mcp_pid }} 2>/dev/null || true
-          kill ${{ steps.run-wizard.outputs.context_mill_pid }} 2>/dev/null || true
+          kill "$MCP_PID" 2>/dev/null || true
+          kill "$CONTEXT_MILL_PID" 2>/dev/null || true
 
           # Extract PR URL
           PR_URL=$(sed -n 's#.*PR: \(https://github.com/[^[:space:]]*\).*#\1#p' wizard-output.log | head -1 || true)
@@ -692,6 +692,11 @@ jobs:
             echo "yara_violation_count=0" >> $GITHUB_OUTPUT
             echo "No YARA report file found"
           fi
+        env:
+          WIZARD_OUTCOME: ${{ steps.execute-wizard.outcome }}
+          MATRIX_APP: ${{ matrix.app }}
+          MCP_PID: ${{ steps.run-wizard.outputs.mcp_pid }}
+          CONTEXT_MILL_PID: ${{ steps.run-wizard.outputs.context_mill_pid }}
 
       - name: Prepare artifact name
         # Not used for anything rn
@@ -699,9 +704,11 @@ jobs:
         id: artifact-name
         run: |
           # Replace slashes with dashes for valid artifact name
-          SAFE_NAME="${{ matrix.app }}"
+          SAFE_NAME="$MATRIX_APP"
           SAFE_NAME="${SAFE_NAME//\//-}"
           echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
+        env:
+          MATRIX_APP: ${{ matrix.app }}
 
       - name: Upload context-mill resources
         # Only upload once (from the first matrix job) since the zip is identical across all jobs

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ services/
 
 ## Wizard local dev stack
 
-The workbench can run the entire Wizard stack in local development mode, with hot reload where supported. It uses `mprocs` to run all the repos defined in your `.env` file:
+The workbench can run the entire Wizard stack in local development mode, with hot reload where supported. It uses `phrocs` to run all the repos defined in your `.env` file:
 
 - [Context Mill repo](https://github.com/PostHog/context-mill)
 - [Wizard repo](https://github.com/PostHog/wizard)
@@ -52,10 +52,10 @@ The workbench can run the entire Wizard stack in local development mode, with ho
 
 ### Setup
 
-Install [mprocs](https://github.com/pvolok/mprocs):
+Install [phrocs](https://github.com/PostHog/posthog/tree/master/tools/phrocs)
 
 ```bash
-brew install mprocs
+brew tap posthog/tap && brew install phrocs
 ```
 
 Install dependencies in this repo:
@@ -84,15 +84,15 @@ Make sure you've set up and installed dependencies for all required repos.
 
 ### Running
 
-Enter `mprocs` to run the local dev stack:
+Enter `phrocs` to run the local dev stack:
 
 ```bash
-mprocs
+phrocs --config mprocs.yaml
 ```
 
-### mprocs Commands
+### phrocs Commands
 
-Use keyboard shortcuts in mprocs: `s` to start, `x` to stop, `r` to restart, `q` to quit.
+Use keyboard shortcuts in phrocs: `r` to start/restart, `s` to stop, `q` to quit.
 
 #### Auto-start Processes (run automatically)
 
@@ -188,6 +188,6 @@ This generates the CA cert at `~/.mitmproxy/mitmproxy-ca-cert.pem` and adds it t
 
 ### Usage
 
-In mprocs, start the `mitmproxy` process first, then start `wizard-run-proxy`. Traffic will appear in the mitmproxy TUI.
+In phrocs, start the `mitmproxy` process first, then start `wizard-run-proxy`. Traffic will appear in the mitmproxy TUI.
 
 Alternatively, you can use [Charles Proxy](https://www.charlesproxy.com/) (GUI-based, paid license) on port `8888` instead of mitmproxy.

--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ Make sure you've set up and installed dependencies for all required repos.
 Enter `phrocs` to run the local dev stack:
 
 ```bash
-phrocs --config mprocs.yaml
+phrocs
 ```
 
 ### phrocs Commands
 
-Use keyboard shortcuts in phrocs: `r` to start/restart, `s` to stop, `q` to quit.
+Use keyboard shortcuts in phrocs: `r` to run/restart, `s` to stop, `q` to quit.
 
 #### Auto-start Processes (run automatically)
 

--- a/proxy/setup-mitmproxy
+++ b/proxy/setup-mitmproxy
@@ -47,6 +47,6 @@ else
 fi
 
 echo ""
-echo "Done. You can now run mprocs and use wizard-run-proxy."
+echo "Done. You can now run phrocs and use wizard-run-proxy."
 echo "To remove the trusted cert later:"
 echo "  sudo security remove-trusted-cert -d $CERT_PEM"

--- a/services/framework-detect/runners/detection.ts
+++ b/services/framework-detect/runners/detection.ts
@@ -113,7 +113,7 @@ export async function runDetection(installDir: string): Promise<DetectionResult>
   const registryPath = join(wizardPath, "dist", "src", "lib", "registry.js");
   if (!existsSync(registryPath)) {
     throw new Error(
-      `Wizard not built — expected ${registryPath}\nRun "pnpm build" in ${wizardPath} (or start wizard-build in mprocs).`,
+      `Wizard not built — expected ${registryPath}\nRun "pnpm build" in ${wizardPath} (or start wizard-build in phrocs).`,
     );
   }
 


### PR DESCRIPTION
Update the setup instructions to use [`phrocs`](https://github.com/PostHog/posthog/blob/master/tools/phrocs/README.md), as a replacement for `mprocs`.

Followup: https://github.com/PostHog/posthog.com/pull/15957