### PR TITLE
fix: remove context limits

### DIFF
--- a/services/pr-evaluator/evaluator.test.ts
+++ b/services/pr-evaluator/evaluator.test.ts
@@ -17,7 +17,6 @@ import {
   type RubricDimension,
   type RubricData,
 } from "./evaluator.js";
-import { truncateDiff, MAX_DIFF_CHARS, MAX_FILE_PATCH_CHARS } from "./git-local.js";
 import type { PRData } from "../github/index.js";
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -295,39 +294,6 @@ describe("validateAndCorrectScores", () => {
     const scores = makeScores({ arch_type: "invalid" as any });
     const result = validateAndCorrectScores(scores);
     assert.equal(result.arch_type, "full-stack");
-  });
-});
-
-// ── truncateDiff ─────────────────────────────────────────────────────────────
-
-describe("truncateDiff", () => {
-  it("returns short diffs unchanged", () => {
-    const diff = "diff --git a/foo.ts b/foo.ts\n+hello";
-    assert.equal(truncateDiff(diff), diff);
-  });
-
-  it("truncates diffs over MAX_DIFF_CHARS", () => {
-    // Build a diff with multiple file sections that exceeds MAX_DIFF_CHARS
-    const fileCount = 10;
-    const perFile = Math.ceil((MAX_DIFF_CHARS + 1000) / fileCount);
-    const sections = Array.from({ length: fileCount }, (_, i) =>
-      `diff --git a/file${i}.ts b/file${i}.ts\n` + "x".repeat(perFile)
-    );
-    const diff = sections.join("\n");
-    const result = truncateDiff(diff);
-    assert.ok(result.includes("[diff truncated at 100k chars]") || result.includes("[patch truncated"));
-    assert.ok(result.length < diff.length, "Result should be shorter than input");
-  });
-
-  it("truncates individual long file patches", () => {
-    // Build a diff that's under MAX_DIFF_CHARS overall but has one huge file patch
-    const longPatch = "diff --git a/big.ts b/big.ts\n" + "x".repeat(MAX_FILE_PATCH_CHARS + 5000);
-    const shortPatch = "diff --git a/small.ts b/small.ts\n+ok";
-    // Total must exceed MAX_DIFF_CHARS for truncateDiff to kick in
-    const padding = "diff --git a/pad.ts b/pad.ts\n" + "y".repeat(MAX_DIFF_CHARS);
-    const diff = longPatch + "\n" + shortPatch + "\n" + padding;
-    const result = truncateDiff(diff);
-    assert.ok(result.includes("[patch truncated"), "Should truncate the long individual patch");
   });
 });
 

--- a/services/pr-evaluator/evaluator.ts
+++ b/services/pr-evaluator/evaluator.ts
@@ -271,9 +271,6 @@ export async function evaluatePR(options: EvaluateOptions): Promise<EvaluateResu
     prompt: userPrompt,
     options: {
       model: process.env.EVALUATOR_MODEL || "claude-opus-4-6",
-      // Cap turns to prevent the agent from exhausting its budget on file reads
-      // without producing the evaluation report (~8.5% failure rate without this)
-      maxTurns: 25,
       allowedTools: ["Read", "Grep", "Glob", "Bash"],
       cwd: process.cwd(),
       // Use acceptEdits instead of bypassPermissions - the latter doesn't work as root in Docker

--- a/services/pr-evaluator/git-local.ts
+++ b/services/pr-evaluator/git-local.ts
@@ -20,39 +20,6 @@ import {
   filterDiff,
 } from "../github/index.js";
 
-// ── Diff truncation ─────────────────────────────────────────────────────────
-
-export const MAX_DIFF_CHARS = 100_000;
-export const MAX_FILE_PATCH_CHARS = 20_000;
-
-/** Truncate oversized diffs to stay within token limits */
-export function truncateDiff(diff: string): string {
-  if (diff.length <= MAX_DIFF_CHARS) return diff;
-
-  // First pass: truncate individual file patches that are too long (at newline boundary)
-  const sections = diff.split(/(?=^diff --git )/m);
-  const truncatedSections = sections.map((section) => {
-    if (section.length <= MAX_FILE_PATCH_CHARS) return section;
-    const cutAt = section.lastIndexOf("\n", MAX_FILE_PATCH_CHARS);
-    const safeCut = cutAt > 0 ? cutAt : MAX_FILE_PATCH_CHARS;
-    return (
-      section.substring(0, safeCut) +
-      `\n... [patch truncated, was ${section.length} chars] ...\n`
-    );
-  });
-
-  let result = truncatedSections.join("");
-
-  // Second pass: truncate overall if still too long (at newline boundary)
-  if (result.length > MAX_DIFF_CHARS) {
-    const cutAt = result.lastIndexOf("\n", MAX_DIFF_CHARS);
-    const safeCut = cutAt > 0 ? cutAt : MAX_DIFF_CHARS;
-    result = result.substring(0, safeCut) + "\n\n[diff truncated at 100k chars]";
-  }
-
-  return result;
-}
-
 // ── Local branch fetching ───────────────────────────────────────────────────
 
 export interface LocalBranchOptions {
@@ -97,9 +64,8 @@ export async function fetchLocalBranch(options: LocalBranchOptions): Promise<PRD
     );
   }
 
-  // Get diff, filter excluded paths, and truncate if oversized
   const rawDiff = getDiff(cwd, mergeBase, actualBranch);
-  const diff = truncateDiff(filterDiff(rawDiff));
+  const diff = filterDiff(rawDiff);
 
   // Get file stats using diff --stat
   const diffStat = getDiffNumstat(cwd, mergeBase, actualBranch);


### PR DESCRIPTION
no more caps leftover from lower context days

originally added to keep things in the context window/prevent turn exhaustion