### PR TITLE
chore: upload wizard artifacts to s3

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -720,38 +720,6 @@ jobs:
           MCP_PID: ${{ steps.run-wizard.outputs.mcp_pid }}
           CONTEXT_MILL_PID: ${{ steps.run-wizard.outputs.context_mill_pid }}
 
-      - name: Prepare artifact name
-        # Not used for anything rn
-        if: always()
-        id: artifact-name
-        run: |
-          # Replace slashes with dashes for valid artifact name
-          SAFE_NAME="$MATRIX_APP"
-          SAFE_NAME="${SAFE_NAME//\//-}"
-          echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
-        env:
-          MATRIX_APP: ${{ matrix.app }}
-
-      - name: Upload context-mill resources
-        # Only upload once (from the first matrix job) since the zip is identical across all jobs
-        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: context-mill-resources-${{ github.run_id }}
-          path: context-mill-mcp-resources.zip
-          if-no-files-found: warn
-
-      - name: Upload skills resources
-        # Only upload once (from the first matrix job) since the zip is identical across all jobs
-        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: skills-resources-${{ github.run_id }}
-          path: skills-mcp-resources.zip
-          if-no-files-found: warn
-
       - name: Configure AWS credentials
         if: always() && !env.ACT
         continue-on-error: true

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -415,6 +415,9 @@ jobs:
     if: always() && needs.discover.result == 'success'
     runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
+    permissions:
+      contents: read
+      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -645,6 +648,7 @@ jobs:
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
           POSTHOG_WIZARD_YARA_REPORT: 'true'
+          POSTHOG_WIZARD_LOG_DIR: /tmp
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Process results
@@ -719,37 +723,41 @@ jobs:
           MCP_PID: ${{ steps.run-wizard.outputs.mcp_pid }}
           CONTEXT_MILL_PID: ${{ steps.run-wizard.outputs.context_mill_pid }}
 
-      - name: Prepare artifact name
-        # Not used for anything rn
-        if: always()
-        id: artifact-name
+      - name: Configure AWS credentials
+        if: always() && !env.ACT
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_WIZARD_ARTIFACTS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_WIZARD_ARTIFACTS_REGION }}
+          mask-aws-account-id: true
+          unset-current-credentials: true
+
+      - name: Upload artifacts to S3
+        if: always() && !env.ACT
+        continue-on-error: true
         run: |
-          # Replace slashes with dashes for valid artifact name
-          SAFE_NAME="$MATRIX_APP"
-          SAFE_NAME="${SAFE_NAME//\//-}"
-          echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
+          SAFE_APP="$MATRIX_APP"
+          SAFE_APP="${SAFE_APP//\//-}"
+          S3_PREFIX="s3://${AWS_BUCKET}/${TRIGGER_ID}/${SAFE_APP}"
+
+          aws s3 cp context-mill-mcp-resources.zip "${S3_PREFIX}/context-mill-mcp-resources.zip" || true
+          aws s3 cp skills-mcp-resources.zip "${S3_PREFIX}/skills-mcp-resources.zip" || true
+
+          WIZARD_LOG="${POSTHOG_WIZARD_LOG_DIR}/posthog-wizard.log"
+          if [ -f "$WIZARD_LOG" ]; then
+            aws s3 cp "$WIZARD_LOG" "${S3_PREFIX}/posthog-wizard.log" || true
+          fi
+
+          YARA_JSON="/tmp/posthog-wizard-yara-report.json"
+          if [ -f "$YARA_JSON" ]; then
+            aws s3 cp "$YARA_JSON" "${S3_PREFIX}/posthog-wizard-yara-report.json" || true
+          fi
         env:
           MATRIX_APP: ${{ matrix.app }}
-
-      - name: Upload context-mill resources
-        # Only upload once (from the first matrix job) since the zip is identical across all jobs
-        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: context-mill-resources-${{ github.run_id }}
-          path: context-mill-mcp-resources.zip
-          if-no-files-found: warn
-
-      - name: Upload skills resources
-        # Only upload once (from the first matrix job) since the zip is identical across all jobs
-        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
-        continue-on-error: true
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
-        with:
-          name: skills-resources-${{ github.run_id }}
-          path: skills-mcp-resources.zip
-          if-no-files-found: warn
+          TRIGGER_ID: ${{ needs.discover.outputs.trigger_id }}
+          AWS_BUCKET: ${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}
+          POSTHOG_WIZARD_LOG_DIR: /tmp
 
       - name: Label and close PR
         if: steps.process-results.outputs.pr_number

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -2,7 +2,6 @@ name: Wizard CI
 
 permissions:
   contents: read
-  id-token: write
 
 on:
   # Scheduled runs (Wed at 11 AM EST / 4 PM UTC)
@@ -414,8 +413,15 @@ jobs:
   wizard-ci:
     needs: [discover, notify-start, notify-pr-start]
     if: always() && needs.discover.result == 'success'
+<<<<<<< HEAD
     runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
+=======
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+>>>>>>> 6eb2cadca (Scope id-token permission to wizard-ci job only)
     strategy:
       fail-fast: false
       max-parallel: 10

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -413,15 +413,11 @@ jobs:
   wizard-ci:
     needs: [discover, notify-start, notify-pr-start]
     if: always() && needs.discover.result == 'success'
-<<<<<<< HEAD
     runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
-=======
-    runs-on: ubuntu-latest
     permissions:
       contents: read
       id-token: write
->>>>>>> 6eb2cadca (Scope id-token permission to wizard-ci job only)
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -652,6 +648,7 @@ jobs:
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
           POSTHOG_WIZARD_YARA_REPORT: 'true'
+          POSTHOG_WIZARD_LOG_DIR: /tmp
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Process results
@@ -740,19 +737,27 @@ jobs:
         if: always() && !env.ACT
         continue-on-error: true
         run: |
-          TRIGGER_ID="${{ needs.discover.outputs.trigger_id }}"
-          SAFE_APP="${{ matrix.app }}"
+          SAFE_APP="$MATRIX_APP"
           SAFE_APP="${SAFE_APP//\//-}"
-          S3_PREFIX="s3://${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}/${TRIGGER_ID}/${SAFE_APP}"
+          S3_PREFIX="s3://${AWS_BUCKET}/${TRIGGER_ID}/${SAFE_APP}"
 
-          aws s3 cp wizard-output.log "${S3_PREFIX}/wizard-output.log" || true
           aws s3 cp context-mill-mcp-resources.zip "${S3_PREFIX}/context-mill-mcp-resources.zip" || true
           aws s3 cp skills-mcp-resources.zip "${S3_PREFIX}/skills-mcp-resources.zip" || true
 
+          WIZARD_LOG="${POSTHOG_WIZARD_LOG_DIR}/posthog-wizard.log"
+          if [ -f "$WIZARD_LOG" ]; then
+            aws s3 cp "$WIZARD_LOG" "${S3_PREFIX}/posthog-wizard.log" || true
+          fi
+
           YARA_JSON="/tmp/posthog-wizard-yara-report.json"
           if [ -f "$YARA_JSON" ]; then
-            aws s3 cp "$YARA_JSON" "${S3_PREFIX}/yara-report.json" || true
+            aws s3 cp "$YARA_JSON" "${S3_PREFIX}/posthog-wizard-yara-report.json" || true
           fi
+        env:
+          MATRIX_APP: ${{ matrix.app }}
+          TRIGGER_ID: ${{ needs.discover.outputs.trigger_id }}
+          AWS_BUCKET: ${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}
+          POSTHOG_WIZARD_LOG_DIR: /tmp
 
       - name: Label and close PR
         if: steps.process-results.outputs.pr_number

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -2,6 +2,7 @@ name: Wizard CI
 
 permissions:
   contents: read
+  id-token: write
 
 on:
   # Scheduled runs (Wed at 11 AM EST / 4 PM UTC)
@@ -750,6 +751,34 @@ jobs:
           name: skills-resources-${{ github.run_id }}
           path: skills-mcp-resources.zip
           if-no-files-found: warn
+
+      - name: Configure AWS credentials
+        if: always() && !env.ACT
+        continue-on-error: true
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
+        with:
+          role-to-assume: ${{ secrets.AWS_WIZARD_ARTIFACTS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_WIZARD_ARTIFACTS_REGION }}
+          mask-aws-account-id: true
+          unset-current-credentials: true
+
+      - name: Upload artifacts to S3
+        if: always() && !env.ACT
+        continue-on-error: true
+        run: |
+          TRIGGER_ID="${{ needs.discover.outputs.trigger_id }}"
+          SAFE_APP="${{ matrix.app }}"
+          SAFE_APP="${SAFE_APP//\//-}"
+          S3_PREFIX="s3://${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}/${TRIGGER_ID}/${SAFE_APP}"
+
+          aws s3 cp wizard-output.log "${S3_PREFIX}/wizard-output.log" || true
+          aws s3 cp context-mill-mcp-resources.zip "${S3_PREFIX}/context-mill-mcp-resources.zip" || true
+          aws s3 cp skills-mcp-resources.zip "${S3_PREFIX}/skills-mcp-resources.zip" || true
+
+          YARA_JSON="/tmp/posthog-wizard-yara-report.json"
+          if [ -f "$YARA_JSON" ]; then
+            aws s3 cp "$YARA_JSON" "${S3_PREFIX}/yara-report.json" || true
+          fi
 
       - name: Label and close PR
         if: steps.process-results.outputs.pr_number

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -415,9 +415,6 @@ jobs:
     if: always() && needs.discover.result == 'success'
     runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
-    permissions:
-      contents: read
-      id-token: write
     strategy:
       fail-fast: false
       max-parallel: 10
@@ -648,7 +645,6 @@ jobs:
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
           POSTHOG_WIZARD_YARA_REPORT: 'true'
-          POSTHOG_WIZARD_LOG_DIR: /tmp
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Process results
@@ -723,41 +719,37 @@ jobs:
           MCP_PID: ${{ steps.run-wizard.outputs.mcp_pid }}
           CONTEXT_MILL_PID: ${{ steps.run-wizard.outputs.context_mill_pid }}
 
-      - name: Configure AWS credentials
-        if: always() && !env.ACT
-        continue-on-error: true
-        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4
-        with:
-          role-to-assume: ${{ secrets.AWS_WIZARD_ARTIFACTS_ROLE_ARN }}
-          aws-region: ${{ secrets.AWS_WIZARD_ARTIFACTS_REGION }}
-          mask-aws-account-id: true
-          unset-current-credentials: true
-
-      - name: Upload artifacts to S3
-        if: always() && !env.ACT
-        continue-on-error: true
+      - name: Prepare artifact name
+        # Not used for anything rn
+        if: always()
+        id: artifact-name
         run: |
-          SAFE_APP="$MATRIX_APP"
-          SAFE_APP="${SAFE_APP//\//-}"
-          S3_PREFIX="s3://${AWS_BUCKET}/${TRIGGER_ID}/${SAFE_APP}"
-
-          aws s3 cp context-mill-mcp-resources.zip "${S3_PREFIX}/context-mill-mcp-resources.zip" || true
-          aws s3 cp skills-mcp-resources.zip "${S3_PREFIX}/skills-mcp-resources.zip" || true
-
-          WIZARD_LOG="${POSTHOG_WIZARD_LOG_DIR}/posthog-wizard.log"
-          if [ -f "$WIZARD_LOG" ]; then
-            aws s3 cp "$WIZARD_LOG" "${S3_PREFIX}/posthog-wizard.log" || true
-          fi
-
-          YARA_JSON="/tmp/posthog-wizard-yara-report.json"
-          if [ -f "$YARA_JSON" ]; then
-            aws s3 cp "$YARA_JSON" "${S3_PREFIX}/posthog-wizard-yara-report.json" || true
-          fi
+          # Replace slashes with dashes for valid artifact name
+          SAFE_NAME="$MATRIX_APP"
+          SAFE_NAME="${SAFE_NAME//\//-}"
+          echo "safe_name=$SAFE_NAME" >> $GITHUB_OUTPUT
         env:
           MATRIX_APP: ${{ matrix.app }}
-          TRIGGER_ID: ${{ needs.discover.outputs.trigger_id }}
-          AWS_BUCKET: ${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}
-          POSTHOG_WIZARD_LOG_DIR: /tmp
+
+      - name: Upload context-mill resources
+        # Only upload once (from the first matrix job) since the zip is identical across all jobs
+        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: context-mill-resources-${{ github.run_id }}
+          path: context-mill-mcp-resources.zip
+          if-no-files-found: warn
+
+      - name: Upload skills resources
+        # Only upload once (from the first matrix job) since the zip is identical across all jobs
+        if: always() && !env.ACT && matrix.app == needs.discover.outputs.first_app
+        continue-on-error: true
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: skills-resources-${{ github.run_id }}
+          path: skills-mcp-resources.zip
+          if-no-files-found: warn
 
       - name: Label and close PR
         if: steps.process-results.outputs.pr_number


### PR DESCRIPTION
Re-open of #941 with signed commits, rebased onto current main. The original branch was too far behind main to merge cleanly under the repo's signed-commits rule (merging brought in 32 ancient unsigned commits from main's history).

## Summary

- Adds OIDC-based AWS credential configuration to the wizard-ci workflow
- Uploads wizard CI artifacts (output logs, context-mill resources, skills resources, YARA reports) to an S3 bucket
- Artifacts are organized by trigger ID and app name: `s3://<bucket>/<trigger-id>/<app-name>/`
- Uses `continue-on-error: true` so S3 upload failures don't break the CI run

## Setup required

After the corresponding [posthog-cloud-infra PR](https://github.com/PostHog/posthog-cloud-infra/pull/7116) is applied, three secrets need to be added to this repo:

- `AWS_WIZARD_ARTIFACTS_ROLE_ARN` — the IAM role ARN from terraform output
- `AWS_WIZARD_ARTIFACTS_REGION` — `us-east-1`
- `AWS_WIZARD_ARTIFACTS_BUCKET` — `posthog-wizard-artifacts-prod-us`

## Test plan

- [ ] Infra PR is applied first to create the S3 bucket and IAM role
- [ ] Secrets are configured in wizard-workbench repo settings
- [ ] Run a wizard-ci workflow and verify artifacts appear in S3 under the expected path