### PR TITLE
Add ./setup script for one-command workbench setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,37 @@ The workbench can run the entire Wizard stack in local development mode, with ho
 ![local dev stack](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_01_26_T20_15_17_777_Z_473d28d6e1.png)
 
 ### Setup
-
-Install [phrocs](https://github.com/PostHog/posthog/tree/master/tools/phrocs)
+One command:
 
 ```bash
-brew tap posthog/tap && brew install phrocs
+bash setup
 ```
 
-Install dependencies in this repo:
+This installs `phrocs`, clones `context-mill`, `wizard`, and `posthog` next to this repo, writes your `.env` with the right paths, prompts for an optional PostHog API key, and runs `pnpm install` everywhere. 
 
-```bash
+macOS only for now.
+
+Flags: 
+`--force` overwrites an existing .env, 
+`--skip-posthog` skips the (large) monorepo clone, 
+`--non-interactive` skips the API key prompt.
+
+<details> <summary>Manual setup (if you'd rather do it yourself)</summary>
+Install phrocs:
+```
+brew tap posthog/tap && brew install phrocs
+```
+Install dependencies in this repo:
+```
 pnpm install
 ```
 
-Copy and edit `.env` with your repo paths and API key:
+Copy and edit .env with your repo paths and API key:
 
-```bash
+```
 cp .env.example .env
 ```
+</details>
 
 ### Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ The workbench can run the entire Wizard stack in local development mode, with ho
 ![local dev stack](https://res.cloudinary.com/dmukukwp6/image/upload/q_auto,f_auto/pasted_image_2026_01_26_T20_15_17_777_Z_473d28d6e1.png)
 
 ### Setup
-One command:
+
+**Starting fresh?** If you've just cloned wizard-workbench and don't already have the dependency repos (`context-mill`, `wizard`, `posthog`) cloned or their packages installed, run:
 
 ```bash
-bash setup
+bash fresh-setup
 ```
 
-This installs `phrocs`, clones `context-mill`, `wizard`, and `posthog` next to this repo, writes your `.env` with the right paths, prompts for an optional PostHog API key, and runs `pnpm install` everywhere. 
+This installs `phrocs`, clones `context-mill`, `wizard`, and `posthog` **as siblings next to this repo** (e.g. `../context-mill`), writes your `.env` with the right paths, prompts for an optional PostHog API key, and runs `pnpm install` everywhere.
 
 macOS only for now.
 
@@ -74,7 +75,9 @@ Flags:
 `--skip-posthog` skips the (large) monorepo clone, 
 `--non-interactive` skips the API key prompt.
 
-<details> <summary>Manual setup (if you'd rather do it yourself)</summary>
+> **Already have the repos / your own setup?** You don't need `fresh-setup` — it's for clean machines. Use the manual steps below to point `.env` at wherever your repos already live (any path works; they don't have to be siblings). `fresh-setup` is also safe to re-run: it skips repos that are already cloned and leaves an existing `.env` alone unless you pass `--force`.
+
+<details> <summary>Manual setup (if you'd rather do it yourself, or already have the repos)</summary>
 Install phrocs:
 ```
 brew tap posthog/tap && brew install phrocs

--- a/fresh-setup
+++ b/fresh-setup
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 #
-# wizard-workbench setup
+# wizard-workbench fresh-setup
+#
+# For a FRESH start: you've just cloned wizard-workbench and do NOT already
+# have the dependency repos (context-mill, wizard, posthog) cloned, nor their
+# packages installed. If you already have those, you don't need this — copy
+# .env.example to .env and edit the paths by hand (see "Manual setup" in the
+# README).
 #
 # Gets a fresh machine from `git clone` to a runnable `phrocs` stack:
 #   1. Checks prerequisites (node, pnpm, git, brew)
@@ -31,7 +37,7 @@ for arg in "$@"; do
     --skip-posthog) SKIP_POSTHOG=1 ;;
     --non-interactive) INTERACTIVE=0 ;;
     -h|--help)
-      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)

--- a/setup
+++ b/setup
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+#
+# wizard-workbench setup
+#
+# Gets a fresh machine from `git clone` to a runnable `phrocs` stack:
+#   1. Checks prerequisites (node, pnpm, git, brew)
+#   2. Installs phrocs via brew tap if missing
+#   3. Clones context-mill, wizard, and posthog as siblings of this repo
+#   4. Writes .env with resolved absolute paths
+#   5. Prompts for a PostHog personal API key (optional)
+#   6. Runs `pnpm install` in each repo
+#
+# Flags:
+#   --force             Overwrite an existing .env
+#   --skip-posthog      Don't clone the posthog monorepo (MCP won't work)
+#   --non-interactive   Don't prompt for the API key (leaves placeholder)
+#
+# To undo: delete the sibling repos and remove .env.
+#
+# macOS only for now (uses Homebrew). PRs welcome for Linux/Windows.
+
+set -euo pipefail
+
+FORCE=0
+SKIP_POSTHOG=0
+INTERACTIVE=1
+
+for arg in "$@"; do
+  case "$arg" in
+    --force) FORCE=1 ;;
+    --skip-posthog) SKIP_POSTHOG=1 ;;
+    --non-interactive) INTERACTIVE=0 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "Unknown flag: $arg" >&2
+      echo "Run with --help for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+REPO_ROOT="$(cd "$(dirname "$0")" && pwd)"
+PARENT="$(cd "$REPO_ROOT/.." && pwd)"
+
+say() { printf "\033[1;36m==>\033[0m %s\n" "$*"; }
+warn() { printf "\033[1;33m!!\033[0m %s\n" "$*" >&2; }
+die() { printf "\033[1;31mxx\033[0m %s\n" "$*" >&2; exit 1; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 1. Preflight
+# ─────────────────────────────────────────────────────────────────────────────
+say "Checking prerequisites..."
+
+[[ "$(uname -s)" == "Darwin" ]] || die "macOS only for now. See script header."
+
+missing=()
+command -v git >/dev/null || missing+=("git (install Xcode command-line tools: xcode-select --install)")
+command -v node >/dev/null || missing+=("node (install via https://nodejs.org or 'brew install node')")
+command -v pnpm >/dev/null || missing+=("pnpm (install via 'brew install pnpm' or 'npm i -g pnpm')")
+command -v brew >/dev/null || missing+=("brew (install via https://brew.sh)")
+
+if (( ${#missing[@]} > 0 )); then
+  echo "Missing prerequisites:" >&2
+  printf "  - %s\n" "${missing[@]}" >&2
+  exit 1
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 2. phrocs
+# ─────────────────────────────────────────────────────────────────────────────
+if ! command -v phrocs >/dev/null; then
+  say "Installing phrocs via Homebrew..."
+  brew tap posthog/tap
+  brew install phrocs
+else
+  say "phrocs already installed: $(command -v phrocs)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 3. Clone sibling repos
+# ─────────────────────────────────────────────────────────────────────────────
+clone_if_missing() {
+  local name="$1" url="$2" dest="$PARENT/$1"
+  if [[ -d "$dest/.git" ]]; then
+    say "$name already cloned at $dest"
+  else
+    say "Cloning $name into $dest..."
+    git clone "$url" "$dest"
+  fi
+}
+
+clone_if_missing "context-mill" "https://github.com/PostHog/context-mill.git"
+clone_if_missing "wizard" "https://github.com/PostHog/wizard.git"
+
+if (( SKIP_POSTHOG == 0 )); then
+  if [[ ! -d "$PARENT/posthog/.git" ]]; then
+    warn "About to clone the PostHog monorepo into $PARENT/posthog. This is large (several GB)."
+    if (( INTERACTIVE == 1 )); then
+      read -r -p "Continue? [y/N] " ans
+      [[ "$ans" =~ ^[Yy]$ ]] || die "Aborted. Re-run with --skip-posthog to skip this step."
+    fi
+  fi
+  clone_if_missing "posthog" "https://github.com/PostHog/posthog.git"
+else
+  warn "Skipping posthog clone. MCP processes in phrocs will fail until you clone it."
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 4. Write .env
+# ─────────────────────────────────────────────────────────────────────────────
+ENV_FILE="$REPO_ROOT/.env"
+EXAMPLE_FILE="$REPO_ROOT/.env.example"
+
+if [[ -f "$ENV_FILE" && $FORCE -eq 0 ]]; then
+  say ".env already exists; leaving it alone. Pass --force to overwrite."
+else
+  say "Writing .env from .env.example..."
+  cp "$EXAMPLE_FILE" "$ENV_FILE"
+  # macOS sed needs the -i '' form.
+  sed -i '' \
+    -e "s|^CONTEXT_MILL_PATH=.*|CONTEXT_MILL_PATH=$PARENT/context-mill|" \
+    -e "s|^COMMANDMENTS_PATH=.*|COMMANDMENTS_PATH=$PARENT/context-mill/transformation-config/commandments.yaml|" \
+    -e "s|^MCP_PATH=.*|MCP_PATH=$PARENT/posthog/services/mcp|" \
+    -e "s|^WIZARD_PATH=.*|WIZARD_PATH=$PARENT/wizard|" \
+    "$ENV_FILE"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 5. API key prompt
+# ─────────────────────────────────────────────────────────────────────────────
+if (( INTERACTIVE == 1 )); then
+  current_key="$(grep -E '^POSTHOG_PERSONAL_API_KEY=' "$ENV_FILE" | head -n1 | cut -d= -f2-)"
+  if [[ "$current_key" == "phx_..." || -z "$current_key" ]]; then
+    echo
+    echo "Optional: PostHog personal API key (only needed for wizard-ci and PR evaluator)."
+    echo "Get one from https://us.posthog.com/settings/user-api-keys — leave blank to skip."
+    read -r -s -p "POSTHOG_PERSONAL_API_KEY: " api_key
+    echo
+    if [[ -n "$api_key" ]]; then
+      sed -i '' -e "s|^POSTHOG_PERSONAL_API_KEY=.*|POSTHOG_PERSONAL_API_KEY=$api_key|" "$ENV_FILE"
+      say "API key saved to .env"
+    else
+      say "Skipping API key (you can edit .env later)."
+    fi
+  else
+    say "POSTHOG_PERSONAL_API_KEY already set in .env"
+  fi
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 6. Install deps
+# ─────────────────────────────────────────────────────────────────────────────
+install_in() {
+  local dir="$1"
+  if [[ -d "$dir" && -f "$dir/package.json" ]]; then
+    say "pnpm install in $dir"
+    (cd "$dir" && pnpm install)
+  else
+    warn "Skipping $dir (not a package directory)"
+  fi
+}
+
+install_in "$REPO_ROOT"
+install_in "$PARENT/context-mill"
+install_in "$PARENT/wizard"
+if (( SKIP_POSTHOG == 0 )) && [[ -d "$PARENT/posthog/services/mcp" ]]; then
+  install_in "$PARENT/posthog/services/mcp"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Done
+# ─────────────────────────────────────────────────────────────────────────────
+cat <<EOF
+
+$(printf "\033[1;32mAll set.\033[0m")
+
+Next steps:
+  cd $REPO_ROOT
+  phrocs
+
+Inside phrocs:
+  - arrow keys to highlight a process
+  - 's' starts a manual process (try 'wizard-run')
+  - 'r' restarts, 'q' quits
+
+EOF


### PR DESCRIPTION
OK, so it's a pain to setup Wizard locally and really complex for idiots like me. 

So, maybe this helps. 

Bundles phrocs install, sibling-repo clones, .env path resolution, optional API key prompt, and pnpm install across all four repos into a single command. Supports --force, --skip-posthog, and --non-interactive flags. README points new users at it and tucks the previous manual steps into a collapsible block.