### PR TITLE
chore: build wizard with build:ci so --ci stays enabled

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -482,7 +482,11 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Building wizard"
-          pnpm build
+          # build:ci inlines NODE_ENV=ci so the binary keeps --ci enabled
+          # (published builds disable it). Otherwise the --ci runs below fail
+          # with "Unknown argument: ci". Requires a wizard ref that has the
+          # build:ci script (PostHog/wizard#499 or later).
+          pnpm build:ci
           echo "::endgroup::"
 
           echo "WIZARD_PATH=$HOME/wizard" >> $GITHUB_ENV


### PR DESCRIPTION
Required for https://github.com/PostHog/wizard/pull/499

Part of project to rip out `--ci` for prod builds because it's mega confusing and the `llm gateway` scope doesn't exist for users anyway.