### PR TITLE
fix: authenticate wizard CI to warlock

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -431,6 +431,10 @@ jobs:
         with:
           app-id: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_APP_ID }}
           private-key: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_PRIVATE_KEY }}
+          owner: PostHog
+          repositories: |
+            wizard-workbench
+            warlock
 
       - name: Checkout repository
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
@@ -489,6 +493,17 @@ jobs:
 
       - name: Clone and build Context Mill
         run: |
+          echo "::group::Configure git auth for private deps"
+          # context-mill depends on the private @posthog/warlock repo. Rewrite its
+          # clone URL to use the App token over HTTPS so the install can fetch it.
+          git config --global \
+            url."https://x-access-token:${APP_TOKEN}@github.com/PostHog/warlock".insteadOf \
+            "https://github.com/PostHog/warlock"
+          git config --global \
+            url."https://x-access-token:${APP_TOKEN}@github.com/PostHog/warlock".insteadOf \
+            "ssh://git@github.com/PostHog/warlock"
+          echo "::endgroup::"
+
           echo "::group::Cloning context-mill repo"
           git clone --depth 1 --branch ${{ needs.discover.outputs.input_context_mill_ref }} \
             https://github.com/PostHog/context-mill.git $HOME/context-mill
@@ -504,6 +519,8 @@ jobs:
           echo "::endgroup::"
 
           echo "CONTEXT_MILL_PATH=$HOME/context-mill" >> $GITHUB_ENV
+        env:
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
 
       - name: Clone PostHog monorepo and install MCP
         run: |


### PR DESCRIPTION
context-mill depends on the private @posthog/warlock repo. The wizard-ci job had no credentials for it, so installing context-mill failed with a git permission error. Scope the App token to also read warlock, and rewrite warlock's git URL to use the token over HTTPS during the install.

messy bits will get cleaned up once npm package publishes, same as context mill