### PR TITLE
Fix the broken yargs mapping

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,4 @@ WIZARD_PATH=~/development/wizard
 POSTHOG_PERSONAL_API_KEY=phx_...
 # POSTHOG_REGION is optional, defaults to 'us'. Can also be passed via --region flag or workflow input.
 # POSTHOG_REGION=us
-# Optional wizard log output directory. Wizard writes posthog-wizard.log inside this directory.
-# POSTHOG_WIZARD_LOG_DIR=/tmp
 POSTHOG_WIZARD_PROJECT_ID=123

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -669,7 +669,6 @@ jobs:
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
           POSTHOG_WIZARD_YARA_REPORT: 'true'
-          POSTHOG_WIZARD_LOG_DIR: /tmp
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Process results
@@ -765,7 +764,7 @@ jobs:
           aws s3 cp context-mill-mcp-resources.zip "${S3_PREFIX}/context-mill-mcp-resources.zip" || true
           aws s3 cp skills-mcp-resources.zip "${S3_PREFIX}/skills-mcp-resources.zip" || true
 
-          WIZARD_LOG="${POSTHOG_WIZARD_LOG_DIR}/posthog-wizard.log"
+          WIZARD_LOG="/tmp/posthog-wizard.log"
           if [ -f "$WIZARD_LOG" ]; then
             aws s3 cp "$WIZARD_LOG" "${S3_PREFIX}/posthog-wizard.log" || true
           fi
@@ -778,7 +777,6 @@ jobs:
           MATRIX_APP: ${{ matrix.app }}
           TRIGGER_ID: ${{ needs.discover.outputs.trigger_id }}
           AWS_BUCKET: ${{ secrets.AWS_WIZARD_ARTIFACTS_BUCKET }}
-          POSTHOG_WIZARD_LOG_DIR: /tmp
 
       - name: Label and close PR
         if: steps.process-results.outputs.pr_number

--- a/README.md
+++ b/README.md
@@ -103,7 +103,6 @@ cp .env.example .env
 | `WIZARD_PATH` | Yes | Path to your local wizard repo (e.g., `~/development/wizard`) |
 | `POSTHOG_PERSONAL_API_KEY` | For CI | PostHog personal API key for wizard CI mode and PR evaluator |
 | `POSTHOG_REGION` | No | PostHog region (`us` or `eu`). Defaults to `us`. Can also be set via `--region` flag or workflow input. |
-| `POSTHOG_WIZARD_LOG_DIR` | No | Directory for wizard verbose logs. Wizard writes `posthog-wizard.log` inside this directory (defaults to `/tmp`). |
 
 Make sure you've set up and installed dependencies for all required repos.
 
@@ -133,7 +132,7 @@ Use keyboard shortcuts in phrocs: `r` to run/restart, `s` to stop, `q` to quit.
 | Process | Description |
 |---------|-------------|
 | `wizard-run` | Interactive picker: choose a wizard command (`posthog-wizard`, `posthog-wizard revenue`, …) then an app |
-| `wizard-tail-run` | Tail the wizard's verbose output (`$POSTHOG_WIZARD_LOG_DIR/posthog-wizard.log`, defaults to `/tmp/posthog-wizard.log`) |
+| `wizard-tail-run` | Tail the wizard's verbose output (`/tmp/posthog-wizard.log`) |
 | `wizard-ci-run` | Full CI flow: run wizard, create PR, evaluate |
 | `wizard-ci-local-run` | CI flow with local evaluation (no PR) |
 | `wizard-ci-create-pr` | Push branch and create PR only (skip wizard run) |

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -68,7 +68,7 @@ procs:
 
   wizard-tail-run:
     # Tail the wizard's verbose output
-    shell: "tail -f \"${POSTHOG_WIZARD_LOG_DIR:-/tmp}/posthog-wizard.log\""
+    shell: "tail -f /tmp/posthog-wizard.log"
     autostart: false
     env_file: .env
 

--- a/services/wizard-benchmark/index.ts
+++ b/services/wizard-benchmark/index.ts
@@ -55,13 +55,12 @@ const PLUGIN_NAMES = [
 ] as const;
 
 function defaultConfig(): BenchmarkConfig {
-  const logDir = process.env.POSTHOG_WIZARD_LOG_DIR || "/tmp";
   return {
     plugins: Object.fromEntries(PLUGIN_NAMES.map((p) => [p, true])),
     output: {
       benchmarkPath: "/tmp/posthog-wizard-benchmark.json",
       benchmarkEnabled: true,
-      logPath: join(logDir, "posthog-wizard.log"),
+      logPath: "/tmp/posthog-wizard.log",
       logEnabled: true,
       suppressWizardLogs: false,
     },


### PR DESCRIPTION
Hello friends, CI breaks again.

<img width="588" height="213" alt="Screenshot 2026-06-03 at 9 46 01 AM" src="https://github.com/user-attachments/assets/66224856-0990-4637-904b-46e1488cb6e6" />

So, this never worked. We tightened rules to error on args that don't exist, this broke CI. We will fix the log dir mess another day.
