### PR TITLE
Rename wizard env vars to WIZARD_ prefix

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ MCP_PATH=~/development/posthog/services/mcp
 WIZARD_PATH=~/development/wizard
 
 # PostHog credentials - used for Wizard CI mode and PR evaluator (via LLM gateway)
-POSTHOG_PERSONAL_API_KEY=phx_...
+WIZARD_API_KEY=phx_...
 # POSTHOG_REGION is optional, defaults to 'us'. Can also be passed via --region flag or workflow input.
 # POSTHOG_REGION=us
-POSTHOG_WIZARD_PROJECT_ID=123
+WIZARD_PROJECT_ID=123

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -625,7 +625,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           # PostHog credentials
           POSTHOG_REGION: ${{ needs.discover.outputs.input_posthog_region }}
-          POSTHOG_PERSONAL_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
+          WIZARD_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
           # Dependency paths
           WIZARD_PATH: ${{ env.WIZARD_PATH }}
           CONTEXT_MILL_PATH: ${{ env.CONTEXT_MILL_PATH }}
@@ -637,7 +637,7 @@ jobs:
           # Source info (for PR body)
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
           # Enable YARA security scanner report
-          POSTHOG_WIZARD_YARA_REPORT: 'true'
+          WIZARD_YARA_REPORT: 'true'
           # PostHog tracking for eval analytics
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
@@ -660,7 +660,7 @@ jobs:
           INPUT_EVALUATE: ${{ needs.discover.outputs.input_evaluate }}
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           POSTHOG_REGION: ${{ needs.discover.outputs.input_posthog_region }}
-          POSTHOG_PERSONAL_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
+          WIZARD_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
           WIZARD_PATH: ${{ env.WIZARD_PATH }}
           CONTEXT_MILL_PATH: ${{ env.CONTEXT_MILL_PATH }}
           MCP_PATH: ${{ env.MCP_PATH }}
@@ -668,7 +668,7 @@ jobs:
           CONTEXT_MILL_REF: ${{ needs.discover.outputs.input_context_mill_ref }}
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
           CI_SOURCE: ${{ needs.discover.outputs.input_source }}
-          POSTHOG_WIZARD_YARA_REPORT: 'true'
+          WIZARD_YARA_REPORT: 'true'
           POSTHOG_PROJECT_TOKEN: ${{ secrets.POSTHOG_PROJECT_TOKEN }}
 
       - name: Process results

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ cp .env.example .env
 | `CONTEXT_MILL_PATH` | Yes | Path to your local context-mill repo (e.g., `~/development/context-mill`) |
 | `MCP_PATH` | Yes | Path to MCP service (e.g., `~/development/posthog/services/mcp`) |
 | `WIZARD_PATH` | Yes | Path to your local wizard repo (e.g., `~/development/wizard`) |
-| `POSTHOG_PERSONAL_API_KEY` | For CI | PostHog personal API key for wizard CI mode and PR evaluator |
+| `WIZARD_API_KEY` | For CI | PostHog personal API key for wizard CI mode and PR evaluator |
 | `POSTHOG_REGION` | No | PostHog region (`us` or `eu`). Defaults to `us`. Can also be set via `--region` flag or workflow input. |
 
 Make sure you've set up and installed dependencies for all required repos.

--- a/fresh-setup
+++ b/fresh-setup
@@ -138,21 +138,21 @@ fi
 # 5. API key prompt
 # ─────────────────────────────────────────────────────────────────────────────
 if (( INTERACTIVE == 1 )); then
-  current_key="$(grep -E '^POSTHOG_PERSONAL_API_KEY=' "$ENV_FILE" | head -n1 | cut -d= -f2-)"
+  current_key="$(grep -E '^WIZARD_API_KEY=' "$ENV_FILE" | head -n1 | cut -d= -f2-)"
   if [[ "$current_key" == "phx_..." || -z "$current_key" ]]; then
     echo
     echo "Optional: PostHog personal API key (only needed for wizard-ci and PR evaluator)."
     echo "Get one from https://us.posthog.com/settings/user-api-keys — leave blank to skip."
-    read -r -s -p "POSTHOG_PERSONAL_API_KEY: " api_key
+    read -r -s -p "WIZARD_API_KEY: " api_key
     echo
     if [[ -n "$api_key" ]]; then
-      sed -i '' -e "s|^POSTHOG_PERSONAL_API_KEY=.*|POSTHOG_PERSONAL_API_KEY=$api_key|" "$ENV_FILE"
+      sed -i '' -e "s|^WIZARD_API_KEY=.*|WIZARD_API_KEY=$api_key|" "$ENV_FILE"
       say "API key saved to .env"
     else
       say "Skipping API key (you can edit .env later)."
     fi
   else
-    say "POSTHOG_PERSONAL_API_KEY already set in .env"
+    say "WIZARD_API_KEY already set in .env"
   fi
 fi
 

--- a/services/pr-evaluator/index.ts
+++ b/services/pr-evaluator/index.ts
@@ -151,14 +151,14 @@ async function main(): Promise<void> {
     }
   }
 
-  // Validate environment - uses PostHog LLM gateway with POSTHOG_PERSONAL_API_KEY
-  if (!process.env.POSTHOG_PERSONAL_API_KEY) {
-    console.error("Error: POSTHOG_PERSONAL_API_KEY environment variable is required");
+  // Validate environment - uses PostHog LLM gateway with WIZARD_API_KEY
+  if (!process.env.WIZARD_API_KEY) {
+    console.error("Error: WIZARD_API_KEY environment variable is required");
     process.exit(1);
   }
   const region = process.env.POSTHOG_REGION || "us";
   // Configure the Claude Agent SDK to use PostHog's LLM gateway
-  configureGateway(process.env.POSTHOG_PERSONAL_API_KEY, region);
+  configureGateway(process.env.WIZARD_API_KEY, region);
 
   // For local branch mode, always use test-run (can't post to GitHub without a PR)
   if (hasBranch && !args.testRun) {

--- a/services/wizard-benchmark/index.ts
+++ b/services/wizard-benchmark/index.ts
@@ -205,13 +205,13 @@ function runBenchmark(
   }
 
   const region = opts.region || (process.env.POSTHOG_REGION as "us" | "eu") || "us";
-  const apiKey = process.env.POSTHOG_PERSONAL_API_KEY;
+  const apiKey = process.env.WIZARD_API_KEY;
 
   if (!apiKey) {
     return Promise.resolve({
       success: false,
       duration: 0,
-      error: "POSTHOG_PERSONAL_API_KEY must be set in .env",
+      error: "WIZARD_API_KEY must be set in .env",
     });
   }
 
@@ -312,7 +312,7 @@ async function main(): Promise<void> {
   // Write config to workbench root
   const configPath = join(WORKBENCH, ".benchmark-config.json");
   writeFileSync(configPath, JSON.stringify(config, null, 2) + "\n", "utf-8");
-  process.env.POSTHOG_WIZARD_BENCHMARK_CONFIG = configPath;
+  process.env.WIZARD_BENCHMARK_CONFIG = configPath;
 
   console.log(`Running benchmark: ${commandToInvocation(command.id)}`);
   console.log(`App: ${selectedApp.name}\n`);

--- a/services/wizard-ci/index.ts
+++ b/services/wizard-ci/index.ts
@@ -279,7 +279,7 @@ function parseArgs(): Options {
 wizard-ci: Run wizard on a single test app and create a PR
 
 Runs wizard in CI mode (non-interactive). Requires POSTHOG_REGION and
-POSTHOG_PERSONAL_API_KEY to be defined in .env file.
+WIZARD_API_KEY to be defined in .env file.
 
 For running all apps, use the wizard-trigger GitHub workflow.
 

--- a/services/wizard-ci/utils.ts
+++ b/services/wizard-ci/utils.ts
@@ -208,13 +208,13 @@ export function runWizard(appPath: string, options: WizardOptions = {}): Promise
   if (options.ci) {
     // Validate CI mode requirements - read from options first, then env vars, with fallback
     const region = options.region || (process.env.POSTHOG_REGION as "us" | "eu") || "us";
-    const apiKey = options.apiKey || process.env.POSTHOG_PERSONAL_API_KEY;
+    const apiKey = options.apiKey || process.env.WIZARD_API_KEY;
 
     if (!apiKey) {
       return Promise.resolve({
         success: false,
         duration: 0,
-        error: "CI mode requires POSTHOG_PERSONAL_API_KEY to be defined in .env file",
+        error: "CI mode requires WIZARD_API_KEY to be defined in .env file",
       });
     }
 

--- a/services/wizard-run/index.ts
+++ b/services/wizard-run/index.ts
@@ -70,7 +70,7 @@ ${WIZARD_COMMANDS.map((c) => `  ${commandToInvocation(c.id).padEnd(28)}  ${c.des
 
 Options:
   --command <id>     Wizard command (see above)
-  --ci               CI mode. Requires POSTHOG_PERSONAL_API_KEY in .env
+  --ci               CI mode. Requires WIZARD_API_KEY in .env
   --region <us|eu>   PostHog region (default: us)
   -h, --help         Show this help message
 `);


### PR DESCRIPTION
POSTHOG_PERSONAL_API_KEY -> WIZARD_API_KEY and POSTHOG_WIZARD_* -> WIZARD_* across services, .env.example, README, fresh-setup, and the CI workflow, matching the wizard's renamed env vars. GH_APP_* secret names are unchanged.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>