### PR TITLE
feat: examples for source maps ci support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ temp/
 
 # Android build artifacts
 **/.cxx/
+
+# @ablaszkiewicz debug files
+scripts/select-app.sh
+Makefile

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/.dockerignore
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env
+.git
+.github

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/Dockerfile
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/Dockerfile
@@ -1,0 +1,30 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+# Compiles the TypeScript app into dist/. The image is built and run by hand
+# (`docker build` / `docker run`) — this project has no CI pipeline.
+FROM node:22-slim AS build
+WORKDIR /app
+
+# Install all dependencies (including dev deps such as typescript) using the lockfile.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Compile src/ -> dist/
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---- Runtime stage ----
+# Ships only production dependencies and the compiled output.
+FROM node:22-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+# POSTHOG_KEY / POSTHOG_HOST are provided at runtime (e.g. `docker run -e ...`).
+CMD ["node", "dist/index.js"]

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "cicd-docker-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cicd-docker-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.29.13",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.13.tgz",
+      "integrity": "sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.376.4"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.376.4",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.376.4.tgz",
+      "integrity": "sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.35.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.35.6.tgz",
+      "integrity": "sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.29.13"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-docker-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-docker-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.dockerignore
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env
+.git
+.github

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.github/workflows/deploy.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: Deploy
+
+# Deploy pipeline: build a Docker image, push it to GHCR, then SSH into the
+# target server and run the freshly built image.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      image: ${{ steps.meta.outputs.tags }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  deploy:
+    name: Deploy to server over SSH
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: SSH into server and run the new image
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: REGISTRY,IMAGE_NAME,GITHUB_SHA
+          script: |
+            set -euo pipefail
+            IMAGE="${REGISTRY}/${IMAGE_NAME}:sha-${GITHUB_SHA}"
+
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login "${REGISTRY}" -u "${{ secrets.GHCR_USER }}" --password-stdin
+            docker pull "${IMAGE}"
+
+            # Replace the running container with the freshly built image.
+            docker rm -f node-raw-app 2>/dev/null || true
+            docker run -d \
+              --name node-raw-app \
+              --restart unless-stopped \
+              -e POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}" \
+              -e POSTHOG_HOST="${{ secrets.POSTHOG_HOST }}" \
+              "${IMAGE}"

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/Dockerfile
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+# Compiles the TypeScript app into dist/.
+FROM node:22-slim AS build
+WORKDIR /app
+
+# Install all dependencies (including dev deps such as typescript) using the lockfile.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Compile src/ -> dist/
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---- Runtime stage ----
+# Ships only production dependencies and the compiled output.
+FROM node:22-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+# POSTHOG_KEY / POSTHOG_HOST are provided at runtime (e.g. `docker run -e ...`).
+CMD ["node", "dist/index.js"]

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "github-actions-docker-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "github-actions-docker-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.29.13",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.13.tgz",
+      "integrity": "sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.376.4"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.376.4",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.376.4.tgz",
+      "integrity": "sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.35.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.35.6.tgz",
+      "integrity": "sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.29.13"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-github-actions-docker-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-docker-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.dockerignore
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env
+.git
+.github

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.github/actions/build-and-push/action.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.github/actions/build-and-push/action.yml
@@ -1,0 +1,53 @@
+name: Build and push image
+description: >-
+  Local composite action that builds the app's Docker image and pushes it to a
+  container registry. The deploy workflow invokes this with `uses:` and passes
+  inputs, instead of inlining the build steps.
+
+inputs:
+  registry:
+    description: Container registry host.
+    required: false
+    default: ghcr.io
+  image-name:
+    description: Image repository name, without the registry prefix.
+    required: true
+  registry-username:
+    description: Username used to authenticate against the registry.
+    required: true
+  registry-password:
+    description: Password or token used to authenticate against the registry.
+    required: true
+
+outputs:
+  image:
+    description: The fully-qualified image reference that was built and pushed.
+    value: ${{ steps.image.outputs.ref }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ inputs.registry }}
+        username: ${{ inputs.registry-username }}
+        password: ${{ inputs.registry-password }}
+
+    - name: Compute image reference
+      id: image
+      shell: bash
+      run: echo "ref=${{ inputs.registry }}/${{ inputs.image-name }}:${{ github.sha }}" >> "$GITHUB_OUTPUT"
+
+    - name: Build and push image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: Dockerfile
+        push: true
+        tags: ${{ steps.image.outputs.ref }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.github/workflows/deploy.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.github/workflows/deploy.yml
@@ -1,0 +1,72 @@
+name: Deploy
+
+# Deploy pipeline. The Docker build/push is not inlined here — it is delegated
+# to a local composite action (.github/actions/build-and-push) that accepts
+# inputs.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build and push image
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      # Delegate the Docker build/push to the nested composite action,
+      # passing registry/image details as inputs.
+      - name: Build and push image
+        id: build
+        uses: ./.github/actions/build-and-push
+        with:
+          registry: ghcr.io
+          image-name: ${{ github.repository }}
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  deploy:
+    name: Deploy to server over SSH
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: SSH into server and run the new image
+        uses: appleboy/ssh-action@v1
+        env:
+          IMAGE: ${{ needs.build.outputs.image }}
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          envs: IMAGE
+          script: |
+            set -euo pipefail
+
+            echo "${{ secrets.GHCR_TOKEN }}" | docker login ghcr.io -u "${{ secrets.GHCR_USER }}" --password-stdin
+            docker pull "${IMAGE}"
+
+            # Replace the running container with the freshly built image.
+            docker rm -f node-raw-app 2>/dev/null || true
+            docker run -d \
+              --name node-raw-app \
+              --restart unless-stopped \
+              -e POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}" \
+              -e POSTHOG_HOST="${{ secrets.POSTHOG_HOST }}" \
+              "${IMAGE}"

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/Dockerfile
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+
+# ---- Build stage ----
+# Compiles the TypeScript app into dist/.
+FROM node:22-slim AS build
+WORKDIR /app
+
+# Install all dependencies (including dev deps such as typescript) using the lockfile.
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Compile src/ -> dist/
+COPY tsconfig.json ./
+COPY src ./src
+RUN npm run build
+
+# ---- Runtime stage ----
+# Ships only production dependencies and the compiled output.
+FROM node:22-slim AS runtime
+ENV NODE_ENV=production
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+
+COPY --from=build /app/dist ./dist
+
+# POSTHOG_KEY / POSTHOG_HOST are provided at runtime (e.g. `docker run -e ...`).
+CMD ["node", "dist/index.js"]

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "cicd-github-actions-nested-docker-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cicd-github-actions-nested-docker-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.29.13",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.13.tgz",
+      "integrity": "sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.376.4"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.376.4",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.376.4.tgz",
+      "integrity": "sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.35.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.35.6.tgz",
+      "integrity": "sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.29.13"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-github-actions-nested-docker-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-nested-docker-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/.github/workflows/deploy.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy
+
+# Deploy pipeline: no Docker. The app is built directly on the GitHub Actions
+# runner, the built output is copied to the server, and the app is restarted
+# over SSH — the server itself never builds anything.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build on the runner, deploy over SSH
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Copy the built app to the server
+        uses: appleboy/scp-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          source: 'dist/*,package.json,package-lock.json'
+          target: /srv/cicd-github-actions-node-raw
+
+      - name: Restart the app on the server
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /srv/cicd-github-actions-node-raw
+            npm ci --omit=dev
+
+            # Replace the running instance with the freshly copied build.
+            pkill -f "node dist/index.js" || true
+            POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}" \
+            POSTHOG_HOST="${{ secrets.POSTHOG_HOST }}" \
+              nohup node dist/index.js > app.log 2>&1 &

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "cicd-github-actions-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cicd-github-actions-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.31.1.tgz",
+      "integrity": "sha512-ZV7qk1lSLpJR7n5HZ/au0iA1H/5TaZjwAF3pVVhQYwCALOSIF5jvnI2X9mvByQIS+wSUckPkZQ+33YaIT6SZJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.384.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.384.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.384.1.tgz",
+      "integrity": "sha512-tzObc/AIunXrKGX3lsPGQ1vs915L0KEChBDmPvgs9PMkCc7sH9eMn8/XKPbZ/BxJALRN8fsWCeSkR2fyoADWvA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.36.10",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.36.10.tgz",
+      "integrity": "sha512-1be0En8VC/GTzGhf8lrIte7W5T4tBOkCYYQTl2FQiAGpIx0kmVRusby3AHXD/dZP44jLN1aMet/a4AvMDjO33g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.31.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-github-actions-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-github-actions-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/.gitlab-ci.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/.gitlab-ci.yml
@@ -1,0 +1,31 @@
+# Deploy pipeline for GitLab CI: build the app in the build job, hand the
+# compiled output to the deploy job as an artifact, then copy it to the server
+# and restart the app over SSH.
+
+stages:
+  - build
+  - deploy
+
+build:
+  stage: build
+  image: node:22-slim
+  script:
+    - npm ci
+    - npm run build
+  artifacts:
+    paths:
+      - dist/
+
+deploy:
+  stage: deploy
+  image: node:22-slim
+  needs:
+    - build
+  environment: production
+  before_script:
+    - apt-get update -qq && apt-get install -y -qq openssh-client rsync
+  script:
+    - rsync -avz --delete dist/ package.json package-lock.json "$DEPLOY_USER@$DEPLOY_HOST:/srv/cicd-gitlab-node-raw/"
+    - ssh "$DEPLOY_USER@$DEPLOY_HOST" "cd /srv/cicd-gitlab-node-raw && npm ci --omit=dev && (pkill -f 'node dist/index.js' || true) && POSTHOG_KEY='$POSTHOG_KEY' POSTHOG_HOST='$POSTHOG_HOST' nohup node dist/index.js > app.log 2>&1 &"
+  rules:
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "cicd-gitlab-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cicd-gitlab-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.31.1.tgz",
+      "integrity": "sha512-ZV7qk1lSLpJR7n5HZ/au0iA1H/5TaZjwAF3pVVhQYwCALOSIF5jvnI2X9mvByQIS+wSUckPkZQ+33YaIT6SZJQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.384.1"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.384.1",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.384.1.tgz",
+      "integrity": "sha512-tzObc/AIunXrKGX3lsPGQ1vs915L0KEChBDmPvgs9PMkCc7sH9eMn8/XKPbZ/BxJALRN8fsWCeSkR2fyoADWvA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.36.10",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.36.10.tgz",
+      "integrity": "sha512-1be0En8VC/GTzGhf8lrIte7W5T4tBOkCYYQTl2FQiAGpIx0kmVRusby3AHXD/dZP44jLN1aMet/a4AvMDjO33g==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.31.1"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-gitlab-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-gitlab-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/.github/workflows/deploy.yml
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy
+
+# Deploy pipeline: no Docker. The job SSHes into the VPS and runs the build and
+# start commands directly on the box — the same steps you'd type by hand after
+# `ssh deploy@your-vps`.
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and run on VPS over SSH
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    environment: production
+    steps:
+      - name: SSH into the VPS, build and run the app
+        uses: appleboy/ssh-action@v1
+        with:
+          host: ${{ secrets.DEPLOY_HOST }}
+          username: ${{ secrets.DEPLOY_USER }}
+          key: ${{ secrets.DEPLOY_SSH_KEY }}
+          script: |
+            set -euo pipefail
+            cd /srv/cicd-ssh-vps-node-raw
+
+            # Pull the latest code and build it on the server.
+            git pull --ff-only origin main
+            npm ci
+            npm run build
+
+            # Stop the previous instance, then start the freshly built app
+            # detached so it keeps running after this SSH session ends.
+            pkill -f "node dist/index.js" || true
+            POSTHOG_KEY="${{ secrets.POSTHOG_KEY }}" \
+            POSTHOG_HOST="${{ secrets.POSTHOG_HOST }}" \
+              nohup node dist/index.js > app.log 2>&1 &

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/.gitignore
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+*.log
+.DS_Store
+.env

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/package-lock.json
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "cicd-ssh-vps-node-raw",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cicd-ssh-vps-node-raw",
+      "version": "0.1.0",
+      "dependencies": {
+        "posthog-node": "^5.35.4"
+      },
+      "devDependencies": {
+        "typescript": "^5.7.2"
+      }
+    },
+    "node_modules/@posthog/core": {
+      "version": "1.29.13",
+      "resolved": "https://registry.npmjs.org/@posthog/core/-/core-1.29.13.tgz",
+      "integrity": "sha512-7Me5zaeAue/wmA364Go8ChYbsVAfNAHbtDxXopWu3D6hq9PVScUcauRgjD1njgvP8NzN91SrIllE+pri3XvJVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/types": "1.376.4"
+      }
+    },
+    "node_modules/@posthog/types": {
+      "version": "1.376.4",
+      "resolved": "https://registry.npmjs.org/@posthog/types/-/types-1.376.4.tgz",
+      "integrity": "sha512-EoDEvA925lf6yxPpbP4wozlXgu4b9WEqxZlFBUDd4k2akP5R/RWyHpvQT8aYyfY6BtSLn8TnVwxPQOM4b90isA==",
+      "license": "MIT"
+    },
+    "node_modules/posthog-node": {
+      "version": "5.35.6",
+      "resolved": "https://registry.npmjs.org/posthog-node/-/posthog-node-5.35.6.tgz",
+      "integrity": "sha512-LwoXnR89A0l75jvFrXjtsAs0BbpyCjnwY8YIUkZT91rt1YnIUfBYiLj7qoUYApdNgesgWQQHqLXxLYX59a6ZYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@posthog/core": "1.29.13"
+      },
+      "engines": {
+        "node": "^20.20.0 || >=22.22.0"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    }
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/package.json
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "cicd-ssh-vps-node-raw",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node --env-file=.env dist/index.js"
+  },
+  "dependencies": {
+    "posthog-node": "^5.35.4"
+  },
+  "devDependencies": {
+    "typescript": "^5.7.2"
+  }
+}

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/src/index.ts
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/src/index.ts
@@ -1,0 +1,10 @@
+import { PostHog } from 'posthog-node'
+
+const client = new PostHog(process.env.POSTHOG_KEY ?? '', {
+  host: process.env.POSTHOG_HOST,
+})
+
+client.capture({ distinctId: 'node-raw', event: 'hello' })
+
+
+await client.shutdown()

--- a/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/tsconfig.json
+++ b/apps/error-tracking-upload-source-maps/cicd-ssh-vps-node-raw/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}

--- a/mprocs.yaml
+++ b/mprocs.yaml
@@ -33,7 +33,7 @@ procs:
     # Dev build of the wizard: points OAuth + host at http://localhost:8010
     # and uses POSTHOG_DEV_CLIENT_ID. Stop wizard-build before starting this
     # (they share dist/) and start your local PostHog on :8010.
-    shell: "source .env && cd $WIZARD_PATH && NODE_ENV=development pnpm build && NODE_ENV=development pnpm build:watch"
+    shell: "source .env && cd $WIZARD_PATH && WIZARD_BUILD_NODE_ENV=development pnpm build:watch"
     autostart: false
     stop_signal: SIGTERM
     env_file: .env


### PR DESCRIPTION
Wizard - https://github.com/PostHog/wizard/pull/651
Context mill - https://github.com/PostHog/context-mill/pull/183

Adds some examples for CI support in wizard:
- github actions + docker,
- github actions + build inside runner, run inside VPS,
- github actions + build and run inside VPS,
- github actions + nested actions,
- gitlab basic example.