### PR TITLE
fix(ci): track wizard CLI overhaul command surface

### DIFF
--- a/apps/manifest.json
+++ b/apps/manifest.json
@@ -8,7 +8,7 @@
       "ciCapable": true
     },
     {
-      "id": "revenue",
+      "id": "revenue-analytics",
       "dir": "revenue",
       "label": "Revenue Analytics",
       "description": "Wire Stripe + PostHog for revenue tracking",

--- a/services/wizard-benchmark/index.ts
+++ b/services/wizard-benchmark/index.ts
@@ -215,10 +215,12 @@ function runBenchmark(
     });
   }
 
-  // Subcommand (e.g. 'revenue') must come before flags
+  // Subcommand (e.g. 'revenue', or a family leaf like 'audit events') must come
+  // before flags. Split on whitespace so multi-token subcommands become
+  // separate argv entries.
   const subcommand = commandToSubcommand(command.id);
   const args: string[] = [wizardBin];
-  if (subcommand) args.push(subcommand);
+  if (subcommand) args.push(...subcommand.split(' '));
   args.push(
     "--local-mcp",
     "--benchmark",

--- a/services/wizard-ci/utils.ts
+++ b/services/wizard-ci/utils.ts
@@ -192,10 +192,12 @@ export function runWizard(appPath: string, options: WizardOptions = {}): Promise
     });
   }
 
-  // Build wizard args — subcommand (e.g. 'revenue') must come before flags
+  // Build wizard args — subcommand (e.g. 'revenue', or a family leaf like
+  // 'audit events') must come before flags. Split on whitespace so multi-token
+  // subcommands become separate argv entries.
   const args = [wizardBin];
   if (options.command) {
-    args.push(options.command);
+    args.push(...options.command.split(' '));
   }
   if (options.skillId) {
     args.push(`--skill=${options.skillId}`);

--- a/services/wizard-commands.ts
+++ b/services/wizard-commands.ts
@@ -52,12 +52,24 @@ function loadManifest(): WizardCommand[] {
 export const WIZARD_COMMANDS: WizardCommand[] = loadManifest();
 
 /**
+ * Family commands (e.g. `audit`) require a concrete leaf in non-interactive
+ * runs — after the CLI overhaul, bare `wizard audit` opens an interactive
+ * picker (or errors under `--ci`) instead of running an audit. Drive a
+ * sensible default leaf so CI keeps exercising the command. `all` runs the
+ * comprehensive audit so CI checks full integrations end-to-end.
+ */
+const FAMILY_DEFAULT_LEAF: Record<string, string> = { audit: 'all' };
+
+/**
  * Convert a command id to the subcommand string the wizard binary expects.
  * 'default' → undefined (no subcommand), 'skill' → undefined (uses --skill flag),
- * any other id → the id itself.
+ * a family id → "<family> <leaf>" (e.g. 'audit' → 'audit events'),
+ * any other id → the id itself. May be multi-token — callers must split on
+ * whitespace before pushing into an argv array.
  */
 export function commandToSubcommand(id: string): string | undefined {
   if (id === 'default' || id === 'skill') return undefined;
+  if (FAMILY_DEFAULT_LEAF[id]) return `${id} ${FAMILY_DEFAULT_LEAF[id]}`;
   return id;
 }
 


### PR DESCRIPTION
Keeps wizard-workbench CI working against the wizard CLI overhaul ([wizard#617](https://github.com/PostHog/wizard/pull/617)).

The overhaul renames `revenue` → `revenue-analytics` and turns `audit` into a family — bare `wizard audit` no longer runs non-interactively. Without this, `/wizard-ci revenue` and `/wizard-ci audit` runs would break.

**Changes**
- `apps/manifest.json`: `revenue` id → `revenue-analytics`
- Drive `wizard audit all` for the audit workflow (full end-to-end integration coverage)
- Split multi-token subcommands when building argv (so `audit all` becomes two args)

Land alongside #617. Kept in draft until it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)