### PR TITLE
ci: install Expo deps in-app for Expo react-native jobs

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -456,11 +456,7 @@ jobs:
   wizard-ci:
     needs: [discover, notify-start, notify-pr-start, setup-deps]
     if: always() && needs.discover.result == 'success'
-    # Swift apps need macOS (Xcode); Expo react-native apps need a runner with
-    # the Expo environment pre-installed (the GitHub-hosted images don't ship it),
-    # so they route to a dedicated self-hosted runner labeled `expo`. Everything
-    # else runs on the standard ubuntu image.
-    runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || contains(matrix.app, 'react-native/expo') && fromJson('["self-hosted", "expo"]') || 'ubuntu-latest' }}
+    runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
     timeout-minutes: 60
     permissions:
       contents: read
@@ -502,6 +498,15 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      # Expo react-native apps live outside the pnpm workspace, so the root
+      # install above never installs their dependencies — including the local
+      # Expo CLI the wizard shells out to. Install them in-app for just the
+      # Expo matrix jobs so the Expo environment is available on ubuntu.
+      - name: Install Expo app dependencies
+        if: contains(matrix.app, 'react-native/expo')
+        run: npm ci
+        working-directory: apps/${{ matrix.app }}
 
       - name: Install GitHub CLI
         run: |

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -456,7 +456,11 @@ jobs:
   wizard-ci:
     needs: [discover, notify-start, notify-pr-start, setup-deps]
     if: always() && needs.discover.result == 'success'
-    runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || 'ubuntu-latest' }}
+    # Swift apps need macOS (Xcode); Expo react-native apps need a runner with
+    # the Expo environment pre-installed (the GitHub-hosted images don't ship it),
+    # so they route to a dedicated self-hosted runner labeled `expo`. Everything
+    # else runs on the standard ubuntu image.
+    runs-on: ${{ contains(matrix.app, 'swift/') && 'macos-latest' || contains(matrix.app, 'react-native/expo') && fromJson('["self-hosted", "expo"]') || 'ubuntu-latest' }}
     timeout-minutes: 60
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Adds a conditional step to the `wizard-ci` matrix job that installs the Expo app's own dependencies (`npm ci`) — but only for `react-native/expo` jobs. This brings in the local Expo CLI the wizard shells out to, so the Expo environment is available on the standard `ubuntu-latest` runner. No special/self-hosted runner needed.

The condition `contains(matrix.app, 'react-native/expo')` matches the `expo-react-native-hacker-news` app and leaves the bare `react-native-saas` app (and everything else) untouched.

## Why

The `expo-react-native-hacker-news` job was failing in CI because Expo wasn't installed. Root cause: each matrix entry runs on its own fresh runner, and the Expo apps live outside the root pnpm workspace (empty `pnpm-workspace.yaml`, no `workspaces` field), so `pnpm install --frozen-lockfile` never installs the Expo app's deps — including its local `expo` package. Installing them in-app for just those jobs fixes it without provisioning a dedicated runner.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1781797842301859?thread_ts=1781797842.301859&cid=C09GTQY5RLZ)*