### PR TITLE
Pin pnpm to 10.29.3 to match the posthog monorepo

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,5 +26,5 @@
     "tsx": "^4.19.0",
     "typescript": "^5.8.0"
   },
-  "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"
+  "packageManager": "pnpm@10.29.3"
 }


### PR DESCRIPTION
There's a pnpm version missmatch that's causing a bunch of `node-gyp` build weirdness like in [this run](https://github.com/PostHog/wizard-workbench/actions/runs/27970043963/job/82775270612)

I think this will help with that 👁️ 