### PR TITLE
ci: set POSTHOG_WIZARD_PROJECT_ID for wizard run

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -639,6 +639,7 @@ jobs:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           POSTHOG_REGION: ${{ needs.discover.outputs.input_posthog_region }}
           POSTHOG_PERSONAL_API_KEY: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_POSTHOG_PERSONAL_KEY }}
+          POSTHOG_WIZARD_PROJECT_ID: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_TARGET_PROJECT_ID }}
           WIZARD_PATH: ${{ env.WIZARD_PATH }}
           CONTEXT_MILL_PATH: ${{ env.CONTEXT_MILL_PATH }}
           MCP_PATH: ${{ env.MCP_PATH }}


### PR DESCRIPTION
The Execute wizard step passed the bot API key but no project id, so the
wizard fell back to a stale/wrong project and bootstrap 403'd on project
data. Pass the bot key's target project explicitly.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>