### PR TITLE
Scope monorepo install to @posthog/mcp in setup-wizard-deps

### DIFF
--- a/.github/actions/setup-wizard-deps/action.yml
+++ b/.github/actions/setup-wizard-deps/action.yml
@@ -195,12 +195,22 @@ runs:
         git checkout -q FETCH_HEAD
         echo "::endgroup::"
 
-        echo "::group::Installing PostCSS dependencies (required for UI apps build)"
-        pnpm add -Dw autoprefixer postcss-preset-env cssnano
+        echo "::group::Installing MCP dependencies (filtered to @posthog/mcp)"
+        # The monorepo is cloned solely to build services/mcp, so install only
+        # that package and its workspace dependencies. A full-workspace install
+        # also fetches and compiles unrelated native addons from plugin-server
+        # (lz4, node-rdkafka), which @posthog/mcp does not use and which break
+        # node-gyp on a cold cache (gyp_main.py "Permission denied", make Error
+        # 126) — the recurring "flaky install" failure. The trailing "..."
+        # selects @posthog/mcp plus its workspace deps and nothing else.
+        pnpm install --frozen-lockfile --filter "@posthog/mcp..."
         echo "::endgroup::"
 
-        echo "::group::Installing MCP dependencies"
-        pnpm install --frozen-lockfile
+        echo "::group::Installing PostCSS dependencies (required for UI apps build)"
+        # PostCSS tooling lives at the workspace root, not in @posthog/mcp, so
+        # add it after the filtered install. --ignore-scripts keeps this step
+        # from rebuilding any native addons it may relink.
+        pnpm add -Dw --ignore-scripts autoprefixer postcss-preset-env cssnano
         echo "::endgroup::"
 
         echo "::group::Building MCP UI apps"


### PR DESCRIPTION
Scopes the PostHog-monorepo install in the `setup-wizard-deps` action to just `@posthog/mcp` and its workspace dependencies, instead of installing the entire workspace.

**Why:** The monorepo is cloned solely to build `services/mcp`, but the step ran a full-workspace `pnpm install`. That pulled in and compiled native addons from unrelated packages (plugin-server's `lz4`, `node-rdkafka`) — which the MCP doesn't depend on — and those are exactly what break `node-gyp` on a cold cache (`gyp_main.py: Permission denied` → `make Error 126`), the recurring "flaky install" failures (run [674ea4c](https://github.com/PostHog/wizard-workbench/actions/runs/28114915371)). Filtering also drops a lot of needless install/build weight from the `setup-deps` job.

**Change:** `pnpm install --frozen-lockfile --filter "@posthog/mcp..."`, with the root PostCSS tooling added afterward via `pnpm add -Dw --ignore-scripts`.

⚠️ Draft: I could not run the full monorepo build in the sandbox (heavy clone + private token), so this needs a real `setup-deps` CI run to confirm the MCP UI-apps build still resolves everything under the filter — in particular that the root PostCSS tooling is still picked up by `build:ui-apps`. Verified that `@posthog/mcp` declares no `lz4`/`node-rdkafka`/`kafkajs` dependency.

Refs #1746

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr) from a [Slack thread](https://posthog.slack.com/archives/C09GTQY5RLZ/p1782319863360659?thread_ts=1782319863.360659&cid=C09GTQY5RLZ)*