### PR TITLE
test(mcp-analytics): add MCP server fixtures for `wizard mcp-analytics`

### DIFF
--- a/apps/manifest.json
+++ b/apps/manifest.json
@@ -30,6 +30,13 @@
       "ciCapable": true
     },
     {
+      "id": "mcp-analytics",
+      "dir": "mcp-analytics",
+      "label": "MCP Analytics",
+      "description": "Instrument an MCP server with the @posthog/mcp SDK",
+      "ciCapable": true
+    },
+    {
       "id": "skill",
       "dir": "misc",
       "label": "Skill",

--- a/apps/mcp-analytics/custom-dispatcher/hono-server/README.md
+++ b/apps/mcp-analytics/custom-dispatcher/hono-server/README.md
@@ -1,0 +1,13 @@
+# wb-mcp-hono-dispatcher
+
+A PostHog-less **custom** MCP dispatcher (Hono HTTP, raw JSON-RPC, no
+`@modelcontextprotocol/sdk` server object). Test fixture for the path-C branch
+of `wizard mcp-analytics`.
+
+Expected wizard outcome (path C — `PostHogMCP`):
+
+- installs `@posthog/mcp` and `posthog-node`
+- creates a `PostHogMCP` client at module scope from `POSTHOG_PROJECT_API_KEY` / `POSTHOG_HOST`
+- calls `captureInitialize(...)` on the `initialize` branch
+- wraps the `tools/call` branch with timing + `captureToolCall({ toolName, parameters, response, durationMs, isError })`
+- flushes (`posthog.flush()`) appropriately for the server's lifecycle

--- a/apps/mcp-analytics/custom-dispatcher/hono-server/package.json
+++ b/apps/mcp-analytics/custom-dispatcher/hono-server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wb-mcp-hono-dispatcher",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "PostHog-less custom MCP dispatcher (Hono, no SDK server object) for testing `wizard mcp-analytics` path C.",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@hono/node-server": "^1.13.7",
+    "hono": "^4.6.14"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/mcp-analytics/custom-dispatcher/hono-server/src/index.ts
+++ b/apps/mcp-analytics/custom-dispatcher/hono-server/src/index.ts
@@ -1,0 +1,91 @@
+import { serve } from '@hono/node-server'
+import { Hono } from 'hono'
+
+// A custom MCP dispatcher: it speaks the MCP JSON-RPC protocol directly over
+// HTTP with no `@modelcontextprotocol/sdk` server object to wrap. The
+// `wizard mcp-analytics` flow should recognize this as path C and instrument it
+// with `PostHogMCP` (captureToolCall / captureInitialize), not `instrument()`.
+
+type JsonRpcRequest = {
+    jsonrpc: '2.0'
+    id: number | string | null
+    method: string
+    params?: Record<string, unknown>
+}
+
+const TOOLS = [
+    {
+        name: 'echo',
+        description: 'Echo a message back to the caller',
+        inputSchema: {
+            type: 'object',
+            properties: { message: { type: 'string' } },
+            required: ['message'],
+        },
+    },
+    {
+        name: 'add',
+        description: 'Add two numbers',
+        inputSchema: {
+            type: 'object',
+            properties: { a: { type: 'number' }, b: { type: 'number' } },
+            required: ['a', 'b'],
+        },
+    },
+]
+
+function runTool(name: string, args: Record<string, unknown>): unknown {
+    switch (name) {
+        case 'echo':
+            return { content: [{ type: 'text', text: String(args.message ?? '') }] }
+        case 'add':
+            return { content: [{ type: 'text', text: String(Number(args.a) + Number(args.b)) }] }
+        default:
+            throw new Error(`unknown tool: ${name}`)
+    }
+}
+
+const app = new Hono()
+
+app.post('/mcp', async (c) => {
+    const body = (await c.req.json()) as JsonRpcRequest
+
+    if (body.method === 'initialize') {
+        return c.json({
+            jsonrpc: '2.0',
+            id: body.id,
+            result: {
+                protocolVersion: '2024-11-05',
+                capabilities: { tools: {} },
+                serverInfo: { name: 'workbench-hono-dispatcher', version: '1.0.0' },
+            },
+        })
+    }
+
+    if (body.method === 'tools/list') {
+        return c.json({ jsonrpc: '2.0', id: body.id, result: { tools: TOOLS } })
+    }
+
+    if (body.method === 'tools/call') {
+        const params = body.params ?? {}
+        const name = String(params.name)
+        const args = (params.arguments as Record<string, unknown>) ?? {}
+        try {
+            return c.json({ jsonrpc: '2.0', id: body.id, result: runTool(name, args) })
+        } catch (err) {
+            return c.json({
+                jsonrpc: '2.0',
+                id: body.id,
+                result: { isError: true, content: [{ type: 'text', text: String(err) }] },
+            })
+        }
+    }
+
+    return c.json({
+        jsonrpc: '2.0',
+        id: body.id,
+        error: { code: -32601, message: `method not found: ${body.method}` },
+    })
+})
+
+serve({ fetch: app.fetch, port: 3000 })

--- a/apps/mcp-analytics/custom-dispatcher/hono-server/tsconfig.json
+++ b/apps/mcp-analytics/custom-dispatcher/hono-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}

--- a/apps/mcp-analytics/typescript-sdk/stdio-server/README.md
+++ b/apps/mcp-analytics/typescript-sdk/stdio-server/README.md
@@ -1,0 +1,12 @@
+# wb-mcp-stdio-server
+
+A PostHog-less MCP server built on the official `@modelcontextprotocol/sdk`
+(`McpServer`, STDIO transport). Test fixture for `wizard mcp-analytics`.
+
+Expected wizard outcome (path A — `instrument()`):
+
+- installs `@posthog/mcp` and `posthog-node`
+- creates a `PostHog` client at module scope from `POSTHOG_PROJECT_API_KEY` / `POSTHOG_HOST`
+- wraps the server: `const analytics = instrument(server, posthog)`
+- adds `posthog.shutdown()` on `SIGTERM`
+- does **not** add any `console.*` logging (STDIO transport)

--- a/apps/mcp-analytics/typescript-sdk/stdio-server/package.json
+++ b/apps/mcp-analytics/typescript-sdk/stdio-server/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "wb-mcp-stdio-server",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "PostHog-less MCP server (official @modelcontextprotocol/sdk, STDIO) for testing `wizard mcp-analytics`.",
+  "scripts": {
+    "build": "tsc --noEmit",
+    "start": "tsx src/index.ts"
+  },
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.12.0",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "tsx": "^4.19.2",
+    "typescript": "^5.6.3"
+  }
+}

--- a/apps/mcp-analytics/typescript-sdk/stdio-server/src/index.ts
+++ b/apps/mcp-analytics/typescript-sdk/stdio-server/src/index.ts
@@ -1,0 +1,32 @@
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import { z } from 'zod'
+
+// A minimal, PostHog-less MCP server. The `wizard mcp-analytics` flow should
+// detect the McpServer object below and wrap it with `instrument(server, posthog)`.
+const server = new McpServer({ name: 'workbench-stdio-server', version: '1.0.0' })
+
+server.tool(
+    'echo',
+    'Echo a message back to the caller',
+    { message: z.string() },
+    async ({ message }) => ({ content: [{ type: 'text', text: message }] })
+)
+
+server.tool(
+    'add',
+    'Add two numbers',
+    { a: z.number(), b: z.number() },
+    async ({ a, b }) => ({ content: [{ type: 'text', text: String(a + b) }] })
+)
+
+async function main(): Promise<void> {
+    const transport = new StdioServerTransport()
+    await server.connect(transport)
+    // STDIO transport: never write to stdout (it is the protocol channel).
+}
+
+main().catch((err) => {
+    process.stderr.write(`fatal: ${String(err)}\n`)
+    process.exit(1)
+})

--- a/apps/mcp-analytics/typescript-sdk/stdio-server/tsconfig.json
+++ b/apps/mcp-analytics/typescript-sdk/stdio-server/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## What

Adds two PostHog-less MCP server test apps for the new `wizard mcp-analytics` command, and registers the `mcp-analytics` workflow in `apps/manifest.json`.

- `apps/mcp-analytics/typescript-sdk/stdio-server` — official `@modelcontextprotocol/sdk` `McpServer` over STDIO → exercises `instrument()` (**path A**)
- `apps/mcp-analytics/custom-dispatcher/hono-server` — a Hono HTTP server speaking raw MCP JSON-RPC with no SDK server object → exercises `PostHogMCP` + `captureToolCall`/`captureInitialize` (**path C**)

Each app ships a README describing the expected wizard outcome.

## Why

Lets the workbench drive `wizard mcp-analytics` end to end against both instrumentation paths (one-line wrap vs. custom dispatcher).

## Related

- context-mill skill: PostHog/context-mill#202
- wizard command: PostHog/wizard#731

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*
