### PR TITLE
ci(wizard-ci): make app discovery depth-agnostic (+ submodule apps)

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -221,25 +221,48 @@ jobs:
       - name: Find available apps
         id: find-apps
         run: |
-          # Apps live under apps/{workflow}/{framework}/{app}, where {workflow}
-          # is the `dir` of a manifest entry with `ciCapable: true`.
-          # .wizard-root marks monorepo roots that should not be recursed into.
+          # An app root is the shallowest dir under a ciCapable workflow that has
+          # a .wizard-root marker or contains files directly; a dir of only
+          # subdirectories is a grouping (e.g. basic-integration/next-js) and is
+          # recursed into. Depth-agnostic — finds 3-level layouts
+          # (basic-integration/{framework}/{app}) and 1-level ones
+          # (error-tracking-upload-source-maps/{app}) alike.
           WORKFLOW_DIRS=$(jq -r '.workflows[] | select(.ciCapable == true) | .dir' apps/manifest.json)
+
+          find_apps() {
+            local base=$1 depth=${2:-1}
+            if [ "$depth" -gt 4 ]; then return; fi
+            for d in "$base"/*/; do
+              d=${d%/}
+              [ -d "$d" ] || continue
+              if [ -f "$d/.wizard-root" ] || find "$d" -maxdepth 1 -type f | grep -q .; then
+                echo "${d#apps/}"
+              else
+                find_apps "$d" $((depth + 1))
+              fi
+            done
+          }
+
           APPS=""
           for wf in $WORKFLOW_DIRS; do
             [ -d "apps/$wf" ] || continue
-            while IFS= read -r dir; do
-              if [ -f "$dir/.wizard-root" ]; then
-                APPS="$APPS
-          $(echo "$dir" | sed 's|apps/||')"
-              else
-                for app in "$dir"/*/; do
-                  [ -d "$app" ] && APPS="$APPS
-          $(echo "${app%/}" | sed 's|apps/||')"
-                done
-              fi
-            done < <(find "apps/$wf" -mindepth 1 -maxdepth 1 -type d | sort)
+            APPS="$APPS
+          $(find_apps "apps/$wf")"
           done
+
+          # Submodule apps (audit/*, migrate/*, self-driving/*) are gitlinks the
+          # file-based finder can't see — they're empty until `git submodule
+          # update`, which discovery skips. Add them by path from .gitmodules
+          # (the submodule path IS the app), filtered to ciCapable workflows.
+          if [ -f .gitmodules ]; then
+            while IFS= read -r sm; do
+              rel=${sm#apps/}
+              if echo "$WORKFLOW_DIRS" | grep -qx "${rel%%/*}"; then
+                APPS="$APPS
+          $rel"
+              fi
+            done < <(git config --file .gitmodules --get-regexp path | awk '{print $2}')
+          fi
 
           APPS=$(echo "$APPS" | sed '/^$/d' | sort)
 


### PR DESCRIPTION
Required for CI for self-driving and source map uploads.

CI run: https://github.com/PostHog/wizard-workbench/actions/runs/28609276548

<details>
<summary>Snapshots — self-driving/turbo-monorepo (intro → outro)</summary>

![01-self-driving-intro](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/01-self-driving-intro.png)

![02-auth](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/02-auth.png)

![03-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/03-run.png)

![04-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/04-run.png)

![05-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/05-run.png)

![06-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/06-run.png)

![07-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/07-run.png)

![08-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/08-run.png)

![09-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/09-run.png)

![10-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/10-run.png)

![11-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/11-run.png)

![12-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/12-run.png)

![13-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/13-run.png)

![14-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/14-run.png)

![15-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/15-run.png)

![16-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/16-run.png)

![17-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/17-run.png)

![18-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/18-run.png)

![19-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/19-run.png)

![20-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/20-run.png)

![21-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/21-run.png)

![22-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/22-run.png)

![23-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/23-run.png)

![24-wizard-ask](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/24-wizard-ask.png)

![25-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/25-run.png)

![26-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/26-run.png)

![27-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/27-run.png)

![28-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/28-run.png)

![29-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/29-run.png)

![30-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/30-run.png)

![31-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/31-run.png)

![32-run](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/32-run.png)

![33-outro](https://raw.githubusercontent.com/PostHog/wizard/sd-snapshot-assets/snapshots/self-driving/33-outro.png)

</details>
