### PR TITLE
fix(wizard-ci): read .ans snapshot frames, not just .txt

### DIFF
--- a/services/wizard-ci/snapshots-review.ts
+++ b/services/wizard-ci/snapshots-review.ts
@@ -157,7 +157,7 @@ async function main(): Promise<number> {
     const txtDest = join(dest, "frames");
     mkdirSync(txtDest, { recursive: true });
     for (const f of readdirSync(txtDir))
-      if (f.endsWith(".txt") && f !== "latest.txt")
+      if ((f.endsWith(".txt") || f.endsWith(".ans")) && f !== "latest.txt")
         cpSync(join(txtDir, f), join(txtDest, f));
   }
 

--- a/services/wizard-ci/snapshots.ts
+++ b/services/wizard-ci/snapshots.ts
@@ -62,7 +62,7 @@ interface Frame {
 function readFrames(dir: string): Frame[] {
   if (!existsSync(dir)) return [];
   return readdirSync(dir)
-    .filter((f) => f.endsWith(".txt"))
+    .filter((f) => f.endsWith(".txt") || f.endsWith(".ans"))
     .sort()
     .map((file) => ({ file, text: readFileSync(join(dir, file), "utf8") }));
 }


### PR DESCRIPTION
The wizard's snapshot harness writes ANSI-preserving `.ans` frames (wizard #730) but the snapshots review path still filtered for `.txt`, so `/wizard-ci-snapshots` runs captured their frames then reported `✖ no snapshots` and failed the job (e.g. wizard#862's run — the agent completed with 34 frames but collection found 0); this accepts both extensions in `snapshots.ts` and `snapshots-review.ts`, matching the already-fixed `e2e.ts`.