### PR TITLE
test(project-detection): add evaluator core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,7 @@ postgres-data/
 coverage/
 test-results/
 test-evaluations/
+artifacts/project-detection-eval/
 playwright-report/
 playwright/.cache/
 

--- a/package.json
+++ b/package.json
@@ -9,8 +9,11 @@
     "wizard-ci-snapshots-review": "tsx services/wizard-ci/snapshots-review.ts",
     "benchmark": "tsx services/wizard-benchmark/index.ts",
     "framework-detect": "tsx services/framework-detect/index.ts",
+    "project-detection-eval": "tsx services/project-detection-eval/index.ts",
     "yara-scan": "tsx services/yara-scan/index.ts",
-    "test:evaluator": "tsx --test services/pr-evaluator/evaluator.test.ts"
+    "test:evaluator": "tsx --test services/pr-evaluator/evaluator.test.ts",
+    "test:project-detection-eval": "tsx --test services/project-detection-eval/**/*.test.ts",
+    "typecheck:project-detection-eval": "tsc --noEmit --strict --module NodeNext --moduleResolution NodeNext --target ES2022 --skipLibCheck services/project-detection-eval/**/*.ts"
   },
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "0.2.73",

--- a/services/project-detection-eval/ADR.md
+++ b/services/project-detection-eval/ADR.md
@@ -1,0 +1,28 @@
+# Project detection evaluation architecture
+
+This ADR defines ownership and evidence boundaries for the credential-free evaluator core.
+
+## Status
+
+Proposed.
+
+## Decisions
+
+1. The evaluator is a sibling service at `services/project-detection-eval`; `framework-detect` remains an interactive debugger.
+2. Cases live in a central catalog. Synthetic fixtures are owned by the evaluator; existing Workbench apps and submodules are referenced without modification.
+3. Valid target IDs are queried from the evaluated Wizard source. Integration IDs come from `FRAMEWORK_REGISTRY`; source-map IDs come from `AUTOMATABLE_VARIANTS`.
+4. Registry cross-check is credential-free and does not claim agentic coverage.
+5. Scripted runners test evaluator behavior only. Their output is labeled `simulated` and never reported as live evidence.
+6. Fixture expectations remain in Workbench. Generic Wizard code must stay fixture-neutral.
+7. Reports contain field-level results and reproducible source fingerprints while excluding secret-named file contents and local absolute paths.
+
+## Rejected alternatives
+
+- Expanding `framework-detect`: conflates debugging with evaluation and changes its lightweight contract.
+- Treating a fake runner as production coverage: tests the comparator at the wrong boundary.
+- Enforcing exact project arrays universally: workspace-root inclusion is case-specific.
+- Placing expectation files in every app: cannot work for externally owned submodules and duplicates existing applications.
+
+## Deferred decisions
+
+Production-path diagnostics, model execution, credential handling, analytics isolation, promotion thresholds, and CI orchestration are follow-up review units. The core report labels those claims blocked rather than replacing them with simulated output.

--- a/services/project-detection-eval/CONTRIBUTING.md
+++ b/services/project-detection-eval/CONTRIBUTING.md
@@ -1,0 +1,21 @@
+# Turn a detection bug into a regression case
+
+This guide adds one durable project-detection case without changing generic detector infrastructure.
+
+1. Minimize the reported repository to the manifests and workspace markers that reproduce the behavior. Keep it under 100 KB and omit credentials, lockfiles that are not signals, generated dependencies, and source code that is irrelevant to detection.
+2. Choose a lowercase hyphenated case ID. Add provenance explaining the failure pattern; link a public issue or PR when one exists.
+3. Put self-authored minimal files under `fixtures/<case-id>/`. Reference an existing Workbench app instead when it already represents the topology. Do not add expectation files to submodules.
+4. Add `cases/<case-id>.json` with `schemaVersion: 1`, fixture ownership, tiers, tags, and one or more consumer expectations.
+5. Mark every project `required`, `optional`, or `forbidden`. Use `optional` for orchestration-only roots until the desired consumer semantics are settled.
+6. Use the evaluated Wizard's production target vocabulary. Integration uses IDs such as `javascript_node`; source maps uses IDs such as `node` and `vite`. Catalog validation rejects cross-profile IDs.
+7. Run the case and confirm the intended field-level failure:
+
+   ```bash
+   WIZARD_PATH=/absolute/path/to/wizard pnpm project-detection-eval --case <case-id> --output-dir /tmp/project-detection-case
+   ```
+
+8. Make the scoped detector or context change in its owning repository. Fixture expectations stay in Workbench; generic Wizard code stays fixture-neutral.
+9. Run `pnpm test:project-detection-eval`, `pnpm typecheck:project-detection-eval`, the complete credential-free corpus, and five consecutive deterministic repetitions.
+10. If the claim needs a real model, stop at the core evaluator boundary. A scripted runner may test evaluator behavior but cannot close a live acceptance criterion; production-path execution belongs in a separately reviewed follow-up.
+
+Do not record or publish model traffic without an approved production-path recording seam. Do not dispatch workflows or publish repository changes as part of local case authoring.

--- a/services/project-detection-eval/README.md
+++ b/services/project-detection-eval/README.md
@@ -1,0 +1,68 @@
+# Project detection evaluation
+
+This service turns Wizard project-discovery regressions into versioned, field-level checks.
+
+It is separate from `framework-detect`: that command remains a quick interactive debugger. This service owns case validation, isolated fixture copies, production target extraction, comparison, and durable reports.
+
+## Evidence modes
+
+| Mode | What it proves | Credentials |
+|---|---|---:|
+| `registry-crosscheck` | Deterministic framework behavior, case validity, reporting, and independent structural observations | No |
+| `simulated` | Evaluator behavior for mismatches, tool policy, recommendation, selection, timeout, and infrastructure responses | No |
+
+Simulated output is evaluator coverage, not production detector evidence. Real model-backed execution is not implemented in this review slice.
+
+## Run the suite
+
+Install the selected Wizard checkout, then run:
+
+```bash
+WIZARD_PATH=/absolute/path/to/wizard pnpm project-detection-eval --output-dir artifacts/project-detection-eval --json
+```
+
+Run one case:
+
+```bash
+WIZARD_PATH=/absolute/path/to/wizard pnpm project-detection-eval --case issue-113-pnpm-next-api --output-dir artifacts/project-detection-eval
+```
+
+The command writes `results.json` and `summary.md`. Each artifact records committed SHAs, non-secret working-tree digests when dirty, the selected Wizard runtime, and a reproduction command.
+
+Validate the harness before trusting a report:
+
+```bash
+pnpm test:project-detection-eval
+pnpm typecheck:project-detection-eval
+```
+
+## Initial cases
+
+- pnpm workspace with Next.js and an API;
+- npm workspaces with a web app and worker;
+- Turborepo with Next.js and Expo.
+
+Cases live in `cases/*.json`. Minimal self-authored inputs live in `fixtures/`; existing Workbench applications can be referenced without modification. Every case declares which project roots are required, optional, or forbidden.
+
+## Failure semantics
+
+Hard fields are project presence and path, repository type, target ID, PostHog presence, recommendation containment, selection, and fallback. Framework display-label differences are warnings unless they imply a functional classification change.
+
+No-manifest, detector, infrastructure, and timeout outcomes stay distinct. A missing fixture or dependency is not reported as a detection mismatch.
+
+## Security and privacy
+
+- Fixture paths must be contained and relative.
+- Runs use throwaway copies when `copyBeforeRun` is true.
+- Persisted reports redact secret-shaped values and local absolute paths.
+- Dirty-tree fingerprints exclude secret-named tracked and untracked file contents and never follow symlink targets.
+- The core evaluator makes no model or gateway request and needs no credential.
+
+## Non-goals
+
+This slice does not prove live project-discovery accuracy, recommendation quality, actual model tool discipline, latency, token use, cost, or analytics isolation. Those require a separately reviewed production-path runner.
+
+## Further reading
+
+- [Architecture decision](./ADR.md)
+- [Adding a regression case](./CONTRIBUTING.md)

--- a/services/project-detection-eval/README.md
+++ b/services/project-detection-eval/README.md
@@ -27,7 +27,7 @@ Run one case:
 WIZARD_PATH=/absolute/path/to/wizard pnpm project-detection-eval --case issue-113-pnpm-next-api --output-dir artifacts/project-detection-eval
 ```
 
-The command writes `results.json` and `summary.md`. Each artifact records committed SHAs, non-secret working-tree digests when dirty, the selected Wizard runtime, and a reproduction command.
+The command writes `results.json` and `summary.md`. Each artifact records committed SHAs, non-secret working-tree digests when dirty, the executed deterministic registry runtime, field-level evidence ownership, and a reproduction command. Haiku, the Agent SDK, and `detectProjectsWithAgent` are future production targets, not executed runtime in registry-crosscheck mode.
 
 Validate the harness before trusting a report:
 

--- a/services/project-detection-eval/__tests__/compare.test.ts
+++ b/services/project-detection-eval/__tests__/compare.test.ts
@@ -1,0 +1,221 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { compareReport, compareToolPolicy } from "../compare/compare.js";
+import { normalizeReport } from "../compare/normalize.js";
+import type { ConsumerExpectation, DetectionReport } from "../types.js";
+
+const expected: ConsumerExpectation = {
+  profile: "headless-integration",
+  expectedOutcome: "success",
+  repoType: "monorepo",
+  projects: [
+    {
+      path: "apps/web",
+      presence: "required",
+      targetId: "nextjs",
+      hasPostHog: false,
+    },
+  ],
+  recommendation: {
+    required: true,
+    acceptablePaths: ["apps/web"],
+    forbiddenPaths: ["packages/docs"],
+    rationale: "primary client",
+  },
+  selectedPath: {
+    acceptablePaths: ["apps/web"],
+    expectedStrategy: "recommended",
+  },
+};
+const report: DetectionReport = {
+  repoType: "monorepo",
+  projects: [
+    {
+      path: "apps/web",
+      framework: "Next.js",
+      targetId: "nextjs",
+      hasPostHog: false,
+      recommended: true,
+    },
+  ],
+  selectedPath: "apps/web",
+  selectedStrategy: "recommended",
+};
+
+test("matching report has no mismatches", () =>
+  assert.deepEqual(compareReport(expected, report), []));
+test("reports every field mismatch", () => {
+  const mismatches = compareReport(expected, {
+    repoType: "single",
+    projects: [
+      {
+        path: "packages/docs",
+        targetId: "javascript_web",
+        hasPostHog: true,
+        recommended: true,
+      },
+    ],
+    selectedPath: "packages/docs",
+    selectedStrategy: "first-instrumentable",
+  });
+  assert.deepEqual(
+    new Set(mismatches.map((item) => item.field)),
+    new Set([
+      "repoType",
+      "projectPresence",
+      "recommendation",
+      "selectedPath",
+      "selectedStrategy",
+    ])
+  );
+});
+test("multiple recommendations hard-fail", () =>
+  assert.equal(
+    compareReport(expected, {
+      ...report,
+      projects: [
+        ...report.projects,
+        {
+          path: "apps/mobile",
+          targetId: "react-native",
+          hasPostHog: false,
+          recommended: true,
+        },
+      ],
+    }).find((item) => item.field === "recommendation")?.severity,
+    "critical"
+  ));
+test("every tool outside the read-only allowlist hard-fails", () => {
+  for (const tool of [
+    "Write",
+    "Edit",
+    "Bash",
+    "WebFetch",
+    "WebSearch",
+    "Agent",
+    "TaskCreate",
+    "mcp__posthog__query",
+    "mcp__wizard-tools__read_file",
+    "UnknownTool",
+  ])
+    assert.equal(
+      compareToolPolicy([{ tool, input: {}, sequence: 1 }])[0].severity,
+      "critical"
+    );
+});
+test("read-only tools pass", () =>
+  assert.deepEqual(
+    compareToolPolicy(
+      ["Read", "Grep", "Glob"].map((tool, sequence) => ({
+        tool,
+        input: {},
+        sequence,
+      }))
+    ),
+    []
+  ));
+test("normalization rejects POSIX and Windows escapes and duplicate paths", () => {
+  for (const path of [
+    "../x",
+    "/tmp/x",
+    "C:\\\\temp\\\\x",
+    "\\\\\\\\server\\\\share",
+  ])
+    assert.throws(() =>
+      normalizeReport({
+        repoType: "single",
+        projects: [{ path, targetId: null, hasPostHog: false }],
+      })
+    );
+  assert.throws(() =>
+    normalizeReport({
+      repoType: "single",
+      projects: [
+        { path: "a", targetId: null, hasPostHog: false },
+        { path: "./a", targetId: null, hasPostHog: false },
+      ],
+    })
+  );
+});
+test("selected path must belong to the detected project set", () =>
+  assert.equal(
+    compareReport(
+      {
+        profile: "headless-integration",
+        expectedOutcome: "success",
+        selectedPath: {
+          acceptablePaths: ["apps/web"],
+          expectedStrategy: "recommended",
+        },
+      },
+      {
+        repoType: "monorepo",
+        projects: [],
+        selectedPath: "apps/web",
+        selectedStrategy: "recommended",
+      }
+    ).find((item) => item.field === "pathContainment")?.severity,
+    "critical"
+  ));
+test("source-map profile uses its own production vocabulary", () =>
+  assert.deepEqual(
+    compareReport(
+      {
+        profile: "source-maps",
+        expectedOutcome: "success",
+        projects: [
+          {
+            path: "frontend",
+            presence: "required",
+            targetId: "vite",
+            hasPostHog: true,
+          },
+        ],
+      },
+      {
+        repoType: "monorepo",
+        projects: [{ path: "frontend", targetId: "vite", hasPostHog: true }],
+      }
+    ),
+    []
+  ));
+test("reports target, PostHog-presence, and framework fields independently", () => {
+  const mismatches = compareReport(
+    {
+      profile: "registry-crosscheck",
+      expectedOutcome: "success",
+      projects: [
+        {
+          path: "apps/web",
+          presence: "required",
+          targetId: "nextjs",
+          hasPostHog: false,
+          acceptedLabels: ["Next.js"],
+        },
+      ],
+    },
+    {
+      repoType: "single",
+      projects: [
+        {
+          path: "apps/web",
+          framework: "Invented",
+          targetId: "javascript_node",
+          hasPostHog: true,
+        },
+      ],
+    }
+  );
+  assert.deepEqual(
+    new Set(mismatches.map((item) => item.field)),
+    new Set(["targetId", "hasPostHog", "framework"])
+  );
+  assert.equal(
+    mismatches.find((item) => item.field === "framework")?.severity,
+    "warning"
+  );
+  assert.equal(
+    mismatches.find((item) => item.field === "hasPostHog")?.severity,
+    "critical"
+  );
+});

--- a/services/project-detection-eval/__tests__/evaluator.test.ts
+++ b/services/project-detection-eval/__tests__/evaluator.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { runRegistryCases, type RegistryDependencies } from "../evaluator.js";
+import type { DetectionCase } from "../types.js";
+
+function fixtureCase(root: string): DetectionCase {
+  const fixture = join(root, "fixture");
+  mkdirSync(fixture);
+  writeFileSync(join(fixture, "package.json"), '{ "name": "fixture" }\n');
+  return {
+    schemaVersion: 1,
+    id: "infrastructure-boundary",
+    description: "Exercises registry runner failures",
+    provenance: { reason: "Regression coverage" },
+    fixture: { kind: "synthetic", path: "fixture", copyBeforeRun: true },
+    tiers: ["pr"],
+    consumers: [
+      {
+        profile: "registry-crosscheck",
+        expectedOutcome: "success",
+        repoType: "single",
+        projects: [
+          {
+            path: ".",
+            presence: "required",
+            targetId: "javascript_node",
+            hasPostHog: false,
+          },
+        ],
+      },
+    ],
+    tags: ["infrastructure"],
+  };
+}
+
+const targets: RegistryDependencies["productionTargets"] = (profile) =>
+  profile === "integration" ? ["javascript_node"] : [];
+
+test("batched detector exceptions become structured infrastructure failures", () => {
+  const root = mkdtempSync(join(tmpdir(), "registry-infrastructure-"));
+  try {
+    const results = runRegistryCases([fixtureCase(root)], root, {
+      productionTargets: targets,
+      detectIntegrations: () => {
+        throw new Error("intentional detector failure");
+      },
+    });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].status, "failed");
+    assert.equal(results[0].checks.infrastructure, "failed");
+    assert.equal(results[0].mismatches[0].actual, "infrastructure-error");
+    assert.match(results[0].mismatches[0].message, /intentional detector/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("batched detector result-count mismatches fail as infrastructure", () => {
+  const root = mkdtempSync(join(tmpdir(), "registry-result-count-"));
+  try {
+    const results = runRegistryCases([fixtureCase(root)], root, {
+      productionTargets: targets,
+      detectIntegrations: () => [],
+    });
+    assert.equal(results.length, 1);
+    assert.equal(results[0].status, "failed");
+    assert.equal(results[0].checks.infrastructure, "failed");
+    assert.match(results[0].mismatches[0].message, /0 results for 1 projects/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/services/project-detection-eval/__tests__/redaction.test.ts
+++ b/services/project-detection-eval/__tests__/redaction.test.ts
@@ -27,6 +27,14 @@ test("redacts embedded home and temporary paths", () => {
   assert.equal(JSON.stringify(value).includes(homedir()), false);
   assert.equal(JSON.stringify(value).includes(tmpdir()), false);
 });
+test("redacts explicitly supplied repository roots", () => {
+  const value = redactValue(
+    "failed in /workspace/wizard/node_modules/.bin/tsx",
+    "/workspace/workbench",
+    ["/workspace/wizard"]
+  );
+  assert.equal(value, "failed in [LOCAL]/node_modules/.bin/tsx");
+});
 test("retains numeric token aggregates while redacting token strings", () =>
   assert.deepEqual(
     redactValue({ inputTokens: 12, accessToken: "pha_secret" }, "/tmp/fixture"),

--- a/services/project-detection-eval/__tests__/redaction.test.ts
+++ b/services/project-detection-eval/__tests__/redaction.test.ts
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { redactValue } from "../reporting/redaction.js";
+
+test("redacts secrets, secret fields, and contained absolute paths", () =>
+  assert.deepEqual(
+    redactValue(
+      {
+        file: "/tmp/fixture/apps/web/package.json",
+        token: "phx_secret",
+        text: "Bearer abc.def",
+      },
+      "/tmp/fixture"
+    ),
+    { file: "apps/web/package.json", token: "[REDACTED]", text: "[REDACTED]" }
+  ));
+test("redacts embedded home and temporary paths", () => {
+  const value = redactValue(
+    {
+      home: `failed at ${join(homedir(), "repo", "file.ts")}`,
+      temp: `copy ${join(tmpdir(), "fixture", "file.ts")}`,
+    },
+    "/unrelated"
+  );
+  assert.equal(JSON.stringify(value).includes(homedir()), false);
+  assert.equal(JSON.stringify(value).includes(tmpdir()), false);
+});
+test("retains numeric token aggregates while redacting token strings", () =>
+  assert.deepEqual(
+    redactValue({ inputTokens: 12, accessToken: "pha_secret" }, "/tmp/fixture"),
+    { inputTokens: 12, accessToken: "[REDACTED]" }
+  ));
+test("redacts project keys and Basic authorization values", () =>
+  assert.deepEqual(
+    redactValue(
+      {
+        projectKey: "phc_project_secret",
+        header: "Basic dXNlcjpwYXNz",
+      },
+      "/tmp/fixture"
+    ),
+    { projectKey: "[REDACTED]", header: "[REDACTED]" }
+  ));

--- a/services/project-detection-eval/__tests__/reporter.test.ts
+++ b/services/project-detection-eval/__tests__/reporter.test.ts
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  evaluationExitCode,
+  markdownSummary,
+  writeArtifacts,
+  type EvaluationArtifact,
+} from "../reporting/reporter.js";
+
+const artifact: EvaluationArtifact = {
+  schemaVersion: 1,
+  runId: "test",
+  generatedAt: "2026-07-13T00:00:00Z",
+  mode: "simulated",
+  wizardSha: "wizard",
+  workbenchSha: "workbench",
+  reproductionCommand: "pnpm project-detection-eval --case mutated",
+  rawArtifactPath: "results.json",
+  liveClaims: "blocked-until-credentialed-isolated-run",
+  results: [
+    {
+      caseId: "mutated",
+      profile: "registry-crosscheck",
+      mode: "simulated",
+      status: "failed",
+      evidenceClass: "Unit-proven",
+      checks: { classification: "failed", liveEvidence: "blocked" },
+      mismatches: [
+        {
+          field: "targetId",
+          severity: "error",
+          projectPath: "apps/web",
+          expected: "nextjs",
+          actual: "javascript_node",
+          message: "target ID differs",
+        },
+      ],
+      durationMs: 1,
+    },
+  ],
+};
+
+test("summary exposes the mismatch, mode, evidence, reproduction, artifact, and live boundary", () => {
+  const markdown = markdownSummary(artifact);
+  for (const value of [
+    "FAIL mutated",
+    "targetId",
+    "nextjs",
+    "javascript_node",
+    "simulated",
+    "Unit-proven",
+    "pnpm project-detection-eval",
+    "results.json",
+    "remain blocked",
+  ])
+    assert.match(markdown, new RegExp(value));
+});
+test("writes parseable JSON and Markdown artifacts", () => {
+  const dir = mkdtempSync(join(tmpdir(), "detection-report-"));
+  try {
+    writeArtifacts(dir, artifact);
+    assert.equal(
+      JSON.parse(readFileSync(join(dir, "results.json"), "utf8")).runId,
+      "test"
+    );
+    assert.match(readFileSync(join(dir, "summary.md"), "utf8"), /FAIL mutated/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+test("deliberate target mutation produces the intended field-level failure", () =>
+  assert.equal(artifact.results[0].mismatches[0].field, "targetId"));
+test("deliberate mutation drives the CI command to a nonzero exit", () =>
+  assert.equal(evaluationExitCode(artifact), 1));
+test("blocked checks are reported separately and exit nonzero", () => {
+  const copy = structuredClone(artifact);
+  copy.results[0].status = "blocked";
+  const markdown = markdownSummary(copy);
+  assert.match(markdown, /0 passed, 0 failed, 1 blocked/);
+  assert.match(markdown, /BLOCKED mutated/);
+  assert.equal(evaluationExitCode(copy), 1);
+});
+test("undefined mismatch values render without crashing", () => {
+  const copy = structuredClone(artifact);
+  copy.results[0].mismatches[0].actual = undefined;
+  assert.match(markdownSummary(copy), /received ` undefined `\./);
+});
+test("malicious backticks cannot escape mismatch code spans", () => {
+  const copy = structuredClone(artifact);
+  copy.results[0].mismatches[0].actual = "`injected`";
+  assert.match(markdownSummary(copy), /`` "`injected`" ``/);
+});
+test("model-controlled project paths cannot inject Markdown or new lines", () => {
+  const copy = structuredClone(artifact);
+  copy.results[0].mismatches[0].projectPath = "apps/`**injected**`\n# heading";
+  const markdown = markdownSummary(copy);
+  assert.match(markdown, /\(`` apps\/`\*\*injected\*\*` # heading ``\)/);
+  assert.doesNotMatch(markdown, /\n# heading/);
+});

--- a/services/project-detection-eval/__tests__/reporter.test.ts
+++ b/services/project-detection-eval/__tests__/reporter.test.ts
@@ -71,6 +71,22 @@ test("writes parseable JSON and Markdown artifacts", () => {
     rmSync(dir, { recursive: true, force: true });
   }
 });
+test("returns the same sanitized artifact written to disk", () => {
+  const dir = mkdtempSync(join(tmpdir(), "detection-report-redacted-"));
+  try {
+    const copy = structuredClone(artifact);
+    copy.results[0].mismatches[0].message =
+      "failed in /workspace/wizard/node_modules/.bin/tsx";
+    const written = writeArtifacts(dir, copy, ["/workspace/wizard"]);
+    const persisted = JSON.parse(
+      readFileSync(join(dir, "results.json"), "utf8")
+    );
+    assert.deepEqual(written, persisted);
+    assert.doesNotMatch(JSON.stringify(written), /\/workspace\/wizard/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
 test("deliberate target mutation produces the intended field-level failure", () =>
   assert.equal(artifact.results[0].mismatches[0].field, "targetId"));
 test("deliberate mutation drives the CI command to a nonzero exit", () =>
@@ -98,5 +114,12 @@ test("model-controlled project paths cannot inject Markdown or new lines", () =>
   copy.results[0].mismatches[0].projectPath = "apps/`**injected**`\n# heading";
   const markdown = markdownSummary(copy);
   assert.match(markdown, /\(`` apps\/`\*\*injected\*\*` # heading ``\)/);
+  assert.doesNotMatch(markdown, /\n# heading/);
+});
+test("detector error messages cannot inject Markdown or new lines", () => {
+  const copy = structuredClone(artifact);
+  copy.results[0].mismatches[0].message = "failed `breakout`\n# heading";
+  const markdown = markdownSummary(copy);
+  assert.match(markdown, /`` failed `breakout` # heading ``/);
   assert.doesNotMatch(markdown, /\n# heading/);
 });

--- a/services/project-detection-eval/__tests__/schema.test.ts
+++ b/services/project-detection-eval/__tests__/schema.test.ts
@@ -1,0 +1,197 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { join, resolve } from "node:path";
+import { loadCases } from "../evaluator.js";
+import {
+  parseDetectionCase,
+  parseDetectionReport,
+  validateCatalog,
+} from "../schema.js";
+
+const service = resolve(import.meta.dirname, "..");
+const valid = () => loadCases(join(service, "cases"))[0];
+
+test("initial three-case catalog validates", () =>
+  assert.equal(loadCases(join(service, "cases")).length, 3));
+test("rejects unknown schema version", () =>
+  assert.throws(() => parseDetectionCase({ ...valid(), schemaVersion: 2 })));
+test("rejects path traversal", () =>
+  assert.throws(() =>
+    parseDetectionCase({
+      ...valid(),
+      fixture: { ...valid().fixture, path: "../escape" },
+    })
+  ));
+test("rejects absolute paths", () =>
+  assert.throws(() =>
+    parseDetectionCase({
+      ...valid(),
+      fixture: { ...valid().fixture, path: "/escape" },
+    })
+  ));
+test("rejects Windows absolute paths", () => {
+  for (const path of ["C:\\\\escape", "\\\\\\\\server\\\\share"])
+    assert.throws(() =>
+      parseDetectionCase({ ...valid(), fixture: { ...valid().fixture, path } })
+    );
+});
+test("rejects missing provenance reason", () =>
+  assert.throws(() =>
+    parseDetectionCase({ ...valid(), provenance: { reason: "" } })
+  ));
+test("rejects duplicate project paths", () => {
+  const item = valid();
+  const consumer = item.consumers[0];
+  assert.throws(() =>
+    parseDetectionCase({
+      ...item,
+      consumers: [
+        {
+          ...consumer,
+          projects: [consumer.projects![0], consumer.projects![0]],
+        },
+      ],
+    })
+  );
+});
+test("rejects duplicate consumer profiles", () => {
+  const item = valid();
+  assert.throws(() =>
+    parseDetectionCase({
+      ...item,
+      consumers: [item.consumers[0], item.consumers[0]],
+    })
+  );
+});
+test("rejects duplicate case IDs", () => {
+  const item = valid();
+  assert.throws(() => validateCatalog([item, item]));
+});
+test("validates detector reports before comparison", () => {
+  assert.equal(
+    parseDetectionReport({
+      repoType: "single",
+      projects: [{ path: ".", targetId: null, hasPostHog: false }],
+    }).projects.length,
+    1
+  );
+  assert.throws(() =>
+    parseDetectionReport({
+      repoType: "single",
+      projects: [{ path: ".", targetId: null }],
+    })
+  );
+  assert.throws(() =>
+    parseDetectionReport({
+      repoType: "single",
+      projects: [],
+      rawOutput: "not allowed",
+    })
+  );
+});
+
+test("rejects uncontained or control-character detector report paths", () => {
+  for (const path of [
+    "../escape",
+    "/escape",
+    "C:\\escape",
+    "\\\\server\\share",
+    "apps/web\nforged",
+  ])
+    assert.throws(() =>
+      parseDetectionReport({
+        repoType: "single",
+        projects: [{ path, targetId: null, hasPostHog: false }],
+      })
+    );
+});
+
+test("rejects every constrained catalog enum and identifier", () => {
+  const mutations: Array<(item: ReturnType<typeof valid>) => void> = [
+    (item) => {
+      item.id = "Not Valid";
+    },
+    (item) => {
+      item.fixture.kind = "unknown" as never;
+    },
+    (item) => {
+      item.tiers = ["unknown" as never];
+    },
+    (item) => {
+      item.consumers[0].profile = "unknown" as never;
+    },
+    (item) => {
+      item.consumers[0].expectedOutcome = "unknown" as never;
+    },
+    (item) => {
+      item.consumers[0].projects![0].presence = "unknown" as never;
+    },
+    (item) => {
+      item.consumers[0].projects![0].role = "unknown" as never;
+    },
+  ];
+  for (const mutate of mutations) {
+    const item = structuredClone(valid());
+    mutate(item);
+    assert.throws(() => parseDetectionCase(item));
+  }
+});
+
+test("rejects empty required catalog collections and strings", () => {
+  const mutations: Array<(item: ReturnType<typeof valid>) => void> = [
+    (item) => {
+      item.tiers = [];
+    },
+    (item) => {
+      item.tags = [];
+    },
+    (item) => {
+      item.tags = [""];
+    },
+    (item) => {
+      item.consumers = [];
+    },
+    (item) => {
+      item.consumers[0].projects![0].targetId = "";
+    },
+    (item) => {
+      item.consumers[0].projects![0].acceptedLabels = [];
+    },
+  ];
+  for (const mutate of mutations) {
+    const item = structuredClone(valid());
+    mutate(item);
+    assert.throws(() => parseDetectionCase(item));
+  }
+});
+
+test("rejects invalid recommendation and selection contracts", () => {
+  const item = structuredClone(valid());
+  item.consumers[0].recommendation = {
+    required: true,
+    acceptablePaths: [],
+    rationale: "",
+  };
+  assert.throws(() => parseDetectionCase(item));
+  item.consumers[0].recommendation = {
+    required: true,
+    acceptablePaths: ["../escape"],
+    rationale: "reason",
+  };
+  assert.throws(() => parseDetectionCase(item));
+  item.consumers[0].recommendation = undefined;
+  item.consumers[0].selectedPath = {
+    acceptablePaths: [],
+    expectedStrategy: "recommended",
+  };
+  assert.throws(() => parseDetectionCase(item));
+  item.consumers[0].selectedPath = {
+    acceptablePaths: ["."],
+    expectedStrategy: "unknown" as "recommended",
+  };
+  assert.throws(() => parseDetectionCase(item));
+});
+
+test("rejects unknown catalog fields", () => {
+  assert.throws(() => parseDetectionCase({ ...valid(), unreviewed: true }));
+});

--- a/services/project-detection-eval/__tests__/selection.test.ts
+++ b/services/project-detection-eval/__tests__/selection.test.ts
@@ -1,0 +1,35 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { selectHeadlessProject } from "../compare/selection.js";
+
+const api = {
+  path: "apps/api",
+  targetId: "javascript_node",
+  hasPostHog: false,
+};
+const web = {
+  path: "apps/web",
+  targetId: "nextjs",
+  hasPostHog: false,
+  recommended: true,
+};
+test("recommended supported project wins", () =>
+  assert.deepEqual(selectHeadlessProject([api, web]), {
+    selectedPath: "apps/web",
+    selectedStrategy: "recommended",
+  }));
+test("recommended project wins even with PostHog", () =>
+  assert.equal(
+    selectHeadlessProject([api, { ...web, hasPostHog: true }]).selectedPath,
+    "apps/web"
+  ));
+test("unsupported recommendation falls back to first instrumentable", () =>
+  assert.deepEqual(selectHeadlessProject([{ ...web, targetId: null }, api]), {
+    selectedPath: "apps/api",
+    selectedStrategy: "first-instrumentable",
+  }));
+test("no eligible project preserves original directory", () =>
+  assert.deepEqual(selectHeadlessProject([{ ...api, hasPostHog: true }]), {
+    selectedPath: null,
+    selectedStrategy: "none-fallback",
+  }));

--- a/services/project-detection-eval/__tests__/simulated.test.ts
+++ b/services/project-detection-eval/__tests__/simulated.test.ts
@@ -1,0 +1,75 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { SimulatedRunner } from "../runners/simulated.js";
+import { compareReport, compareToolPolicy } from "../compare/compare.js";
+import { selectHeadlessProject } from "../compare/selection.js";
+import type { ConsumerExpectation, DetectedProject } from "../types.js";
+
+const expectation: ConsumerExpectation = {
+  profile: "headless-integration",
+  expectedOutcome: "success",
+  recommendation: {
+    required: true,
+    acceptablePaths: ["apps/web"],
+    forbiddenPaths: ["packages/docs"],
+    rationale: "primary client",
+  },
+  selectedPath: {
+    acceptablePaths: ["apps/web"],
+    expectedStrategy: "recommended",
+  },
+};
+const projects: DetectedProject[] = [
+  { path: "apps/api", targetId: "javascript_node", hasPostHog: false },
+  { path: "apps/web", targetId: "nextjs", hasPostHog: true, recommended: true },
+];
+
+test("simulated PR #884 contract covers recommendation and selection without claiming live evidence", () => {
+  const selection = selectHeadlessProject(projects);
+  const runner = new SimulatedRunner(
+    new Map([
+      [
+        "case",
+        {
+          status: "completed",
+          report: { repoType: "monorepo", projects, ...selection },
+          toolCalls: [
+            {
+              tool: "Glob",
+              input: { pattern: "**/{package.json}" },
+              sequence: 0,
+            },
+          ],
+          durationMs: 10,
+        },
+      ],
+    ])
+  );
+  const run = runner.run("case");
+  assert.equal(run.mode, "simulated");
+  assert.deepEqual(compareReport(expectation, run.report!), []);
+  assert.deepEqual(compareToolPolicy(run.toolCalls), []);
+});
+
+test("missing scripted response is infrastructure failure", () =>
+  assert.equal(
+    new SimulatedRunner(new Map()).run("missing").status,
+    "infrastructure-error"
+  ));
+test("preserves timeout as a distinct runner result", () =>
+  assert.equal(
+    new SimulatedRunner(
+      new Map([
+        [
+          "slow",
+          {
+            status: "timeout",
+            toolCalls: [],
+            durationMs: 30_000,
+            error: "deadline exceeded",
+          },
+        ],
+      ])
+    ).run("slow").status,
+    "timeout"
+  ));

--- a/services/project-detection-eval/__tests__/source-state.test.ts
+++ b/services/project-detection-eval/__tests__/source-state.test.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { trackedSourceDigest, untrackedSourceDigest } from "../source-state.js";
+
+test("source digests include ordinary files without reading secret files or symlink targets", () => {
+  const root = mkdtempSync(join(tmpdir(), "source-state-"));
+  const outside = join(tmpdir(), `source-state-outside-${process.pid}`);
+  try {
+    writeFileSync(join(root, "source.ts"), "first");
+    writeFileSync(join(root, ".env.local"), "first-secret");
+    writeFileSync(outside, "first-outside");
+    symlinkSync(outside, join(root, "outside-link"));
+    assert.throws(
+      () => untrackedSourceDigest(root, ["../outside"]),
+      /escapes repository/
+    );
+    const first = untrackedSourceDigest(root, [
+      "source.ts",
+      ".env.local",
+      "outside-link",
+    ]);
+
+    writeFileSync(join(root, ".env.local"), "second-secret");
+    writeFileSync(outside, "second-outside");
+    const excludedChanges = untrackedSourceDigest(root, [
+      "source.ts",
+      ".env.local",
+      "outside-link",
+    ]);
+    assert.deepEqual(excludedChanges, first);
+
+    writeFileSync(join(root, "source.ts"), "second");
+    const sourceChange = untrackedSourceDigest(root, [
+      "source.ts",
+      ".env.local",
+      "outside-link",
+    ]);
+    assert.notDeepEqual(sourceChange, first);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+    try {
+      unlinkSync(outside);
+    } catch {
+      /* already absent */
+    }
+  }
+});
+
+test("tracked source digests also exclude secret-named file contents", () => {
+  const root = mkdtempSync(join(tmpdir(), "tracked-source-state-"));
+  try {
+    writeFileSync(join(root, "source.ts"), "first");
+    writeFileSync(join(root, ".env.production"), "first-secret");
+    const first = trackedSourceDigest(root, ["source.ts", ".env.production"]);
+
+    writeFileSync(join(root, ".env.production"), "second-secret");
+    assert.deepEqual(
+      trackedSourceDigest(root, ["source.ts", ".env.production"]),
+      first
+    );
+
+    writeFileSync(join(root, "source.ts"), "second");
+    assert.notDeepEqual(
+      trackedSourceDigest(root, ["source.ts", ".env.production"]),
+      first
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/services/project-detection-eval/cases/issue-113-npm-vite-workers.json
+++ b/services/project-detection-eval/cases/issue-113-npm-vite-workers.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "id": "issue-113-npm-vite-workers",
+  "description": "npm workspace with Vite React client and Node worker",
+  "provenance": { "reason": "Covers silent root catch-all and client/server distinction", "issueUrls": ["https://github.com/PostHog/wizard/issues/113"] },
+  "fixture": { "kind": "synthetic", "path": "services/project-detection-eval/fixtures/issue-113-npm-vite-workers", "copyBeforeRun": true },
+  "tiers": ["pr", "nightly"],
+  "consumers": [
+    { "profile": "registry-crosscheck", "expectedOutcome": "success", "repoType": "monorepo", "projects": [
+      { "path": ".", "presence": "optional", "role": "workspace-root", "hasPostHog": false },
+      { "path": "apps/web", "presence": "required", "role": "client", "targetId": "javascript_node", "hasPostHog": false },
+      { "path": "workers/events", "presence": "required", "role": "server", "targetId": "javascript_node", "hasPostHog": false }
+    ] },
+    { "profile": "headless-integration", "expectedOutcome": "success", "repoType": "monorepo", "projects": [
+      { "path": ".", "presence": "optional", "role": "workspace-root", "hasPostHog": false },
+      { "path": "apps/web", "presence": "required", "role": "client", "targetId": "javascript_web", "hasPostHog": false },
+      { "path": "workers/events", "presence": "required", "role": "server", "targetId": "javascript_node", "hasPostHog": false }
+    ] }
+  ],
+  "tags": ["issue-113", "npm", "vite", "react", "node", "monorepo"]
+}

--- a/services/project-detection-eval/cases/issue-113-pnpm-next-api.json
+++ b/services/project-detection-eval/cases/issue-113-pnpm-next-api.json
@@ -1,0 +1,14 @@
+{
+  "schemaVersion": 1,
+  "id": "issue-113-pnpm-next-api",
+  "description": "pnpm workspace with a Next.js client and Node API",
+  "provenance": { "reason": "Mirrors Wizard issue #113 multi-project topology", "issueUrls": ["https://github.com/PostHog/wizard/issues/113"] },
+  "fixture": { "kind": "synthetic", "path": "services/project-detection-eval/fixtures/issue-113-pnpm-next-api", "copyBeforeRun": true },
+  "tiers": ["pr", "nightly"],
+  "consumers": [{ "profile": "registry-crosscheck", "expectedOutcome": "success", "repoType": "monorepo", "projects": [
+    { "path": ".", "presence": "optional", "role": "workspace-root", "hasPostHog": false },
+    { "path": "apps/web", "presence": "required", "role": "client", "targetId": "nextjs", "hasPostHog": false },
+    { "path": "services/api", "presence": "required", "role": "server", "targetId": "javascript_node", "hasPostHog": false }
+  ] }],
+  "tags": ["issue-113", "pnpm", "nextjs", "node", "monorepo"]
+}

--- a/services/project-detection-eval/cases/turbo-next-expo.json
+++ b/services/project-detection-eval/cases/turbo-next-expo.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "id": "turbo-next-expo",
+  "description": "Turborepo with equally credible Next.js and Expo clients",
+  "provenance": { "reason": "Models the ambiguous multi-client topology from issue discussion", "customerPattern": "pnpm Turborepo with web and mobile clients" },
+  "fixture": { "kind": "synthetic", "path": "services/project-detection-eval/fixtures/turbo-next-expo", "copyBeforeRun": true },
+  "tiers": ["pr", "nightly", "experimental"],
+  "consumers": [
+    { "profile": "registry-crosscheck", "expectedOutcome": "success", "repoType": "monorepo", "projects": [
+      { "path": ".", "presence": "optional", "role": "workspace-root", "hasPostHog": false },
+      { "path": "apps/mobile", "presence": "required", "role": "client", "targetId": "react-native", "hasPostHog": false },
+      { "path": "apps/web", "presence": "required", "role": "client", "targetId": "nextjs", "hasPostHog": false }
+    ] },
+    { "profile": "headless-integration", "expectedOutcome": "success", "repoType": "monorepo", "projects": [
+      { "path": ".", "presence": "optional", "role": "workspace-root", "hasPostHog": false },
+      { "path": "apps/mobile", "presence": "required", "role": "client", "targetId": "react-native", "hasPostHog": false },
+      { "path": "apps/web", "presence": "required", "role": "client", "targetId": "nextjs", "hasPostHog": false }
+    ], "recommendation": { "required": false, "acceptablePaths": ["apps/web", "apps/mobile"], "forbiddenPaths": ["."], "rationale": "Both client applications are credible; workspace root is not" }, "selectedPath": { "acceptablePaths": ["apps/web", "apps/mobile"], "expectedStrategy": "recommended" } }
+  ],
+  "tags": ["pnpm", "turbo", "nextjs", "expo", "react-native", "ambiguous"]
+}

--- a/services/project-detection-eval/compare/compare.ts
+++ b/services/project-detection-eval/compare/compare.ts
@@ -1,0 +1,167 @@
+import type {
+  ConsumerExpectation,
+  DetectionReport,
+  Mismatch,
+  ToolCall,
+} from "../types.js";
+
+const allowedTools = new Set(["Glob", "Read", "Grep"]);
+
+export function compareToolPolicy(calls: ToolCall[]): Mismatch[] {
+  return calls
+    .filter((call) => !allowedTools.has(call.tool))
+    .map((call) => ({
+      field: "toolPolicy",
+      severity: "critical",
+      expected: "Glob, Read, or Grep",
+      actual: call.tool,
+      message: `forbidden model tool call at sequence ${call.sequence}: ${call.tool}`,
+    }));
+}
+
+export function compareReport(
+  expected: ConsumerExpectation,
+  actual: DetectionReport
+): Mismatch[] {
+  const out: Mismatch[] = [];
+  if (expected.repoType && expected.repoType !== actual.repoType)
+    out.push({
+      field: "repoType",
+      severity: "error",
+      expected: expected.repoType,
+      actual: actual.repoType,
+      message: "repository type differs",
+    });
+  const byPath = new Map(
+    actual.projects.map((project) => [project.path, project])
+  );
+  for (const project of expected.projects ?? []) {
+    const found = byPath.get(project.path);
+    if (project.presence === "forbidden" && found)
+      out.push({
+        field: "projectPresence",
+        severity: "critical",
+        projectPath: project.path,
+        expected: "absent",
+        actual: "present",
+        message: "forbidden project was detected",
+      });
+    if (project.presence === "required" && !found)
+      out.push({
+        field: "projectPresence",
+        severity: "critical",
+        projectPath: project.path,
+        expected: "present",
+        actual: "absent",
+        message: "required project was not detected",
+      });
+    if (!found || project.presence === "forbidden") continue;
+    if (project.targetId !== undefined && project.targetId !== found.targetId)
+      out.push({
+        field: "targetId",
+        severity: "error",
+        projectPath: project.path,
+        expected: project.targetId,
+        actual: found.targetId,
+        message: "target ID differs",
+      });
+    if (
+      project.hasPostHog !== undefined &&
+      project.hasPostHog !== found.hasPostHog
+    )
+      out.push({
+        field: "hasPostHog",
+        severity: "critical",
+        projectPath: project.path,
+        expected: project.hasPostHog,
+        actual: found.hasPostHog,
+        message: "PostHog presence differs",
+      });
+    if (
+      project.acceptedLabels?.length &&
+      found.framework &&
+      !project.acceptedLabels.includes(found.framework)
+    )
+      out.push({
+        field: "framework",
+        severity: "warning",
+        projectPath: project.path,
+        expected: project.acceptedLabels,
+        actual: found.framework,
+        message: "framework display label is not accepted",
+      });
+  }
+  const recommended = actual.projects.filter((project) => project.recommended);
+  if (recommended.length > 1)
+    out.push({
+      field: "recommendation",
+      severity: "critical",
+      expected: "at most one",
+      actual: recommended.map((item) => item.path),
+      message: "multiple projects were recommended",
+    });
+  if (expected.recommendation) {
+    const path = recommended[0]?.path;
+    if (expected.recommendation.required && !path)
+      out.push({
+        field: "recommendation",
+        severity: "error",
+        expected: expected.recommendation.acceptablePaths,
+        actual: null,
+        message: "required recommendation is absent",
+      });
+    if (path && !byPath.has(path))
+      out.push({
+        field: "recommendation",
+        severity: "critical",
+        expected: "detected project",
+        actual: path,
+        message: "recommendation is outside the detected project set",
+      });
+    if (path && expected.recommendation.forbiddenPaths?.includes(path))
+      out.push({
+        field: "recommendation",
+        severity: "critical",
+        expected: `not ${path}`,
+        actual: path,
+        message: "explicitly forbidden project was recommended",
+      });
+    if (path && !expected.recommendation.acceptablePaths.includes(path))
+      out.push({
+        field: "recommendation",
+        severity: "error",
+        expected: expected.recommendation.acceptablePaths,
+        actual: path,
+        message: "recommendation is not acceptable",
+      });
+  }
+  if (expected.selectedPath) {
+    if (
+      !expected.selectedPath.acceptablePaths.includes(actual.selectedPath ?? "")
+    )
+      out.push({
+        field: "selectedPath",
+        severity: "critical",
+        expected: expected.selectedPath.acceptablePaths,
+        actual: actual.selectedPath,
+        message: "consumer selected an unacceptable path",
+      });
+    if (actual.selectedPath && !byPath.has(actual.selectedPath))
+      out.push({
+        field: "pathContainment",
+        severity: "critical",
+        expected: "detected project path",
+        actual: actual.selectedPath,
+        message: "consumer selected a path outside the detected project set",
+      });
+    if (actual.selectedStrategy !== expected.selectedPath.expectedStrategy)
+      out.push({
+        field: "selectedStrategy",
+        severity: "error",
+        expected: expected.selectedPath.expectedStrategy,
+        actual: actual.selectedStrategy,
+        message: "selection strategy differs",
+      });
+  }
+  return out;
+}

--- a/services/project-detection-eval/compare/normalize.ts
+++ b/services/project-detection-eval/compare/normalize.ts
@@ -1,0 +1,38 @@
+import { posix, win32 } from "node:path";
+import type { DetectionReport } from "../types.js";
+
+export function normalizePath(value: string): string {
+  const unix = value.replaceAll("\\", "/").replace(/^\.\//, "");
+  if (
+    posix.isAbsolute(unix) ||
+    win32.isAbsolute(value) ||
+    unix.split("/").includes("..")
+  )
+    throw new Error(`path escapes fixture: ${value}`);
+  const normalized = posix.normalize(unix || ".");
+  return normalized === "" ? "." : normalized;
+}
+
+export function normalizeReport(report: DetectionReport): DetectionReport {
+  const seen = new Set<string>();
+  const projects = report.projects
+    .map((project) => ({ ...project, path: normalizePath(project.path) }))
+    .sort((a, b) => a.path.localeCompare(b.path));
+  for (const project of projects) {
+    if (seen.has(project.path))
+      throw new Error(`duplicate detected project path: ${project.path}`);
+    seen.add(project.path);
+  }
+  return {
+    ...report,
+    projects,
+    ...(report.selectedPath !== undefined
+      ? {
+          selectedPath:
+            report.selectedPath === null
+              ? null
+              : normalizePath(report.selectedPath),
+        }
+      : {}),
+  };
+}

--- a/services/project-detection-eval/compare/selection.ts
+++ b/services/project-detection-eval/compare/selection.ts
@@ -1,0 +1,24 @@
+import type { DetectionReport, DetectedProject } from "../types.js";
+
+function supported(project: DetectedProject): boolean {
+  return project.targetId !== null;
+}
+
+export function selectHeadlessProject(
+  projects: DetectedProject[]
+): Pick<DetectionReport, "selectedPath" | "selectedStrategy"> {
+  const recommended = projects.find(
+    (project) => project.recommended && supported(project)
+  );
+  if (recommended)
+    return { selectedPath: recommended.path, selectedStrategy: "recommended" };
+  const instrumentable = projects.find(
+    (project) => supported(project) && !project.hasPostHog
+  );
+  if (instrumentable)
+    return {
+      selectedPath: instrumentable.path,
+      selectedStrategy: "first-instrumentable",
+    };
+  return { selectedPath: null, selectedStrategy: "none-fallback" };
+}

--- a/services/project-detection-eval/evaluator.ts
+++ b/services/project-detection-eval/evaluator.ts
@@ -22,6 +22,16 @@ import { compareReport } from "./compare/compare.js";
 import { normalizeReport } from "./compare/normalize.js";
 import { detectIntegrations, productionTargets } from "./wizard-runner.js";
 
+export type RegistryDependencies = {
+  detectIntegrations(paths: string[]): Array<string | null>;
+  productionTargets(profile: "integration" | "source-maps"): string[];
+};
+
+const productionDependencies: RegistryDependencies = {
+  detectIntegrations,
+  productionTargets,
+};
+
 const MANIFESTS = new Set([
   "package.json",
   "pyproject.toml",
@@ -146,9 +156,12 @@ export function materialize(
   };
 }
 
-export function validateTargets(testCase: DetectionCase): string[] {
-  const integration = new Set(productionTargets("integration"));
-  const sourceMaps = new Set(productionTargets("source-maps"));
+export function validateTargets(
+  testCase: DetectionCase,
+  targets: RegistryDependencies["productionTargets"] = productionTargets
+): string[] {
+  const integration = new Set(targets("integration"));
+  const sourceMaps = new Set(targets("source-maps"));
   const errors: string[] = [];
   for (const consumer of testCase.consumers)
     for (const project of consumer.projects ?? []) {
@@ -163,40 +176,75 @@ export function validateTargets(testCase: DetectionCase): string[] {
   return errors;
 }
 
+function infrastructureFailure(
+  testCase: DetectionCase,
+  consumer: ConsumerExpectation,
+  started: number,
+  error: unknown
+): EvaluationResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    caseId: testCase.id,
+    profile: consumer.profile,
+    mode: "registry-crosscheck",
+    status: "failed",
+    evidenceClass: "Deterministic integration-proven",
+    checks: { infrastructure: "failed" },
+    mismatches: [
+      {
+        field: "outcome",
+        severity: "critical",
+        expected: consumer.expectedOutcome,
+        actual: "infrastructure-error",
+        message,
+      },
+    ],
+    durationMs: Date.now() - started,
+  };
+}
+
 export function runRegistryCase(
   testCase: DetectionCase,
-  workbenchRoot: string
+  workbenchRoot: string,
+  dependencies: RegistryDependencies = productionDependencies
 ): EvaluationResult[] {
   const consumer = testCase.consumers.find(
     (item) => item.profile === "registry-crosscheck"
   );
   if (!consumer) return [];
   const started = Date.now();
-  const targetErrors = validateTargets(testCase);
-  if (targetErrors.length)
-    return [
-      {
-        caseId: testCase.id,
-        profile: consumer.profile,
-        mode: "registry-crosscheck",
-        status: "failed",
-        evidenceClass: "Deterministic integration-proven",
-        checks: { schema: "failed" },
-        mismatches: targetErrors.map((message) => ({
-          field: "schema",
-          severity: "critical",
-          expected: "production target",
-          actual: message,
-          message,
-        })),
-        durationMs: Date.now() - started,
-      },
-    ];
   let materialized: ReturnType<typeof materialize> | undefined;
   try {
+    const targetErrors = validateTargets(
+      testCase,
+      dependencies.productionTargets
+    );
+    if (targetErrors.length)
+      return [
+        {
+          caseId: testCase.id,
+          profile: consumer.profile,
+          mode: "registry-crosscheck",
+          status: "failed",
+          evidenceClass: "Deterministic integration-proven",
+          checks: { schema: "failed" },
+          mismatches: targetErrors.map((message) => ({
+            field: "schema",
+            severity: "critical",
+            expected: "production target",
+            actual: message,
+            message,
+          })),
+          durationMs: Date.now() - started,
+        },
+      ];
     materialized = materialize(testCase, workbenchRoot);
     const roots = [...walk(materialized.root)];
-    const targets = detectIntegrations(roots);
+    const targets = dependencies.detectIntegrations(roots);
+    if (targets.length !== roots.length)
+      throw new Error(
+        `detector returned ${targets.length} results for ${roots.length} projects`
+      );
     const projects: DetectedProject[] = roots.map((path, index) => ({
       path: fixtureRelative(materialized!.root, path),
       targetId: targets[index],
@@ -252,27 +300,7 @@ export function runRegistryCase(
       },
     ];
   } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return [
-      {
-        caseId: testCase.id,
-        profile: consumer.profile,
-        mode: "registry-crosscheck",
-        status: "failed",
-        evidenceClass: "Deterministic integration-proven",
-        checks: { infrastructure: "failed" },
-        mismatches: [
-          {
-            field: "outcome",
-            severity: "critical",
-            expected: consumer.expectedOutcome,
-            actual: "infrastructure-error",
-            message,
-          },
-        ],
-        durationMs: Date.now() - started,
-      },
-    ];
+    return [infrastructureFailure(testCase, consumer, started, error)];
   } finally {
     materialized?.cleanup();
   }
@@ -281,7 +309,8 @@ export function runRegistryCase(
 /** Evaluate a corpus through one Wizard subprocess so detector timeout timers overlap. */
 export function runRegistryCases(
   cases: DetectionCase[],
-  workbenchRoot: string
+  workbenchRoot: string,
+  dependencies: RegistryDependencies = productionDependencies
 ): EvaluationResult[] {
   const prepared: Array<{
     testCase: DetectionCase;
@@ -297,7 +326,14 @@ export function runRegistryCases(
         (item) => item.profile === "registry-crosscheck"
       );
       if (!consumer) continue;
-      const errors = validateTargets(testCase);
+      const started = Date.now();
+      let errors: string[];
+      try {
+        errors = validateTargets(testCase, dependencies.productionTargets);
+      } catch (error) {
+        early.push(infrastructureFailure(testCase, consumer, started, error));
+        continue;
+      }
       if (errors.length) {
         early.push({
           caseId: testCase.id,
@@ -313,7 +349,7 @@ export function runRegistryCases(
             actual: message,
             message,
           })),
-          durationMs: 0,
+          durationMs: Date.now() - started,
         });
         continue;
       }
@@ -324,32 +360,28 @@ export function runRegistryCases(
           consumer,
           materialized,
           roots: [...walk(materialized.root)],
-          started: Date.now(),
+          started,
         });
       } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        early.push({
-          caseId: testCase.id,
-          profile: consumer.profile,
-          mode: "registry-crosscheck",
-          status: "failed",
-          evidenceClass: "Deterministic integration-proven",
-          checks: { infrastructure: "failed" },
-          mismatches: [
-            {
-              field: "outcome",
-              severity: "critical",
-              expected: consumer.expectedOutcome,
-              actual: "infrastructure-error",
-              message,
-            },
-          ],
-          durationMs: 0,
-        });
+        early.push(infrastructureFailure(testCase, consumer, started, error));
       }
     }
     const allRoots = prepared.flatMap((item) => item.roots);
-    const allTargets = detectIntegrations(allRoots);
+    let allTargets: Array<string | null>;
+    try {
+      allTargets = dependencies.detectIntegrations(allRoots);
+      if (allTargets.length !== allRoots.length)
+        throw new Error(
+          `detector returned ${allTargets.length} results for ${allRoots.length} projects`
+        );
+    } catch (error) {
+      return [
+        ...early,
+        ...prepared.map(({ testCase, consumer, started }) =>
+          infrastructureFailure(testCase, consumer, started, error)
+        ),
+      ];
+    }
     let offset = 0;
     const results = prepared.map(
       ({ testCase, consumer, materialized, roots, started }) => {

--- a/services/project-detection-eval/evaluator.ts
+++ b/services/project-detection-eval/evaluator.ts
@@ -188,7 +188,7 @@ function infrastructureFailure(
     profile: consumer.profile,
     mode: "registry-crosscheck",
     status: "failed",
-    evidenceClass: "Deterministic integration-proven",
+    evidenceClass: "Mixed deterministic evidence",
     checks: { infrastructure: "failed" },
     mismatches: [
       {
@@ -226,7 +226,7 @@ export function runRegistryCase(
           profile: consumer.profile,
           mode: "registry-crosscheck",
           status: "failed",
-          evidenceClass: "Deterministic integration-proven",
+          evidenceClass: "Mixed deterministic evidence",
           checks: { schema: "failed" },
           mismatches: targetErrors.map((message) => ({
             field: "schema",
@@ -280,7 +280,15 @@ export function runRegistryCase(
         status: mismatches.some((item) => item.severity !== "warning")
           ? "failed"
           : "passed",
-        evidenceClass: "Deterministic integration-proven",
+        evidenceClass: "Mixed deterministic evidence",
+        fieldEvidence: {
+          projectRoots: "Evaluator-owned deterministic fixture oracle",
+          frameworkTarget: "Wizard deterministic registry integration",
+          hasPostHog: "Evaluator heuristic",
+          agenticDiscovery: "Blocked",
+          recommendation: "Blocked",
+          liveToolDiscipline: "Blocked",
+        },
         checks: {
           schema: "passed",
           discovery: mismatches.some((item) => item.field === "projectPresence")
@@ -340,7 +348,7 @@ export function runRegistryCases(
           profile: consumer.profile,
           mode: "registry-crosscheck",
           status: "failed",
-          evidenceClass: "Deterministic integration-proven",
+          evidenceClass: "Mixed deterministic evidence",
           checks: { schema: "failed" },
           mismatches: errors.map((message) => ({
             field: "schema",
@@ -421,7 +429,15 @@ export function runRegistryCases(
           status: mismatches.some((item) => item.severity !== "warning")
             ? ("failed" as const)
             : ("passed" as const),
-          evidenceClass: "Deterministic integration-proven" as const,
+          evidenceClass: "Mixed deterministic evidence" as const,
+          fieldEvidence: {
+            projectRoots: "Evaluator-owned deterministic fixture oracle",
+            frameworkTarget: "Wizard deterministic registry integration",
+            hasPostHog: "Evaluator heuristic",
+            agenticDiscovery: "Blocked",
+            recommendation: "Blocked",
+            liveToolDiscipline: "Blocked",
+          },
           checks: {
             schema: "passed" as const,
             discovery: mismatches.some(

--- a/services/project-detection-eval/evaluator.ts
+++ b/services/project-detection-eval/evaluator.ts
@@ -1,0 +1,438 @@
+import {
+  cpSync,
+  existsSync,
+  lstatSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { basename, dirname, join, relative, resolve, sep } from "node:path";
+import type {
+  ConsumerExpectation,
+  DetectedProject,
+  DetectionCase,
+  DetectionReport,
+  EvaluationResult,
+  Mismatch,
+} from "./types.js";
+import { parseDetectionCase, validateCatalog } from "./schema.js";
+import { compareReport } from "./compare/compare.js";
+import { normalizeReport } from "./compare/normalize.js";
+import { detectIntegrations, productionTargets } from "./wizard-runner.js";
+
+const MANIFESTS = new Set([
+  "package.json",
+  "pyproject.toml",
+  "requirements.txt",
+  "setup.py",
+  "Pipfile",
+  "manage.py",
+  "Gemfile",
+  "composer.json",
+  "Cargo.toml",
+  "go.mod",
+  "mix.exs",
+  "pom.xml",
+  "Package.swift",
+  "Podfile",
+  "project.yml",
+  "pubspec.yaml",
+  "build.gradle",
+  "build.gradle.kts",
+  "settings.gradle",
+  "settings.gradle.kts",
+]);
+const IGNORED = new Set([
+  "node_modules",
+  "dist",
+  "build",
+  ".next",
+  "out",
+  "coverage",
+  "vendor",
+  ".venv",
+  "target",
+  "Pods",
+  "Carthage",
+  "DerivedData",
+  ".git",
+]);
+
+function walk(
+  root: string,
+  current = root,
+  found = new Set<string>()
+): Set<string> {
+  for (const entry of readdirSync(current)) {
+    if (IGNORED.has(entry)) continue;
+    const path = join(current, entry);
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) continue;
+    if (stat.isDirectory()) walk(root, path, found);
+    else if (
+      MANIFESTS.has(entry) ||
+      entry.endsWith(".csproj") ||
+      entry === "project.pbxproj"
+    ) {
+      let project = dirname(path);
+      if (
+        entry === "project.pbxproj" &&
+        basename(project).endsWith(".xcodeproj")
+      )
+        project = dirname(project);
+      found.add(project);
+    }
+  }
+  return found;
+}
+
+function hasPostHog(path: string): boolean {
+  for (const file of readdirSync(path)) {
+    if (
+      !MANIFESTS.has(file) &&
+      !file.endsWith(".csproj") &&
+      file !== "project.pbxproj"
+    )
+      continue;
+    try {
+      if (/posthog/i.test(readFileSync(join(path, file), "utf8"))) return true;
+    } catch {
+      /* reported as a comparison mismatch */
+    }
+  }
+  return false;
+}
+
+function detectRepoType(root: string): "single" | "monorepo" {
+  if (
+    ["pnpm-workspace.yaml", "turbo.json", "nx.json", "lerna.json"].some(
+      (file) => existsSync(join(root, file))
+    )
+  )
+    return "monorepo";
+  const packageJson = join(root, "package.json");
+  if (existsSync(packageJson))
+    try {
+      if (JSON.parse(readFileSync(packageJson, "utf8")).workspaces)
+        return "monorepo";
+    } catch {
+      /* malformed input remains a fixture signal */
+    }
+  return "single";
+}
+
+function fixtureRelative(root: string, path: string): string {
+  return relative(root, path).split(sep).join("/") || ".";
+}
+
+export function materialize(
+  testCase: DetectionCase,
+  workbenchRoot: string
+): { root: string; cleanup(): void } {
+  const source = resolve(workbenchRoot, testCase.fixture.path);
+  if (!source.startsWith(resolve(workbenchRoot) + sep) || !existsSync(source))
+    throw new Error(`fixture unavailable: ${testCase.fixture.path}`);
+  if (!testCase.fixture.copyBeforeRun) return { root: source, cleanup() {} };
+  const parent = mkdtempSync(
+    join(tmpdir(), `wizard-detection-${testCase.id}-`)
+  );
+  const root = join(parent, "fixture");
+  cpSync(source, root, { recursive: true, dereference: false });
+  return {
+    root,
+    cleanup: () => rmSync(parent, { recursive: true, force: true }),
+  };
+}
+
+export function validateTargets(testCase: DetectionCase): string[] {
+  const integration = new Set(productionTargets("integration"));
+  const sourceMaps = new Set(productionTargets("source-maps"));
+  const errors: string[] = [];
+  for (const consumer of testCase.consumers)
+    for (const project of consumer.projects ?? []) {
+      if (project.targetId === undefined || project.targetId === null) continue;
+      const valid =
+        consumer.profile === "source-maps" ? sourceMaps : integration;
+      if (!valid.has(project.targetId))
+        errors.push(
+          `${testCase.id}/${consumer.profile}: invalid production target ${project.targetId}`
+        );
+    }
+  return errors;
+}
+
+export function runRegistryCase(
+  testCase: DetectionCase,
+  workbenchRoot: string
+): EvaluationResult[] {
+  const consumer = testCase.consumers.find(
+    (item) => item.profile === "registry-crosscheck"
+  );
+  if (!consumer) return [];
+  const started = Date.now();
+  const targetErrors = validateTargets(testCase);
+  if (targetErrors.length)
+    return [
+      {
+        caseId: testCase.id,
+        profile: consumer.profile,
+        mode: "registry-crosscheck",
+        status: "failed",
+        evidenceClass: "Deterministic integration-proven",
+        checks: { schema: "failed" },
+        mismatches: targetErrors.map((message) => ({
+          field: "schema",
+          severity: "critical",
+          expected: "production target",
+          actual: message,
+          message,
+        })),
+        durationMs: Date.now() - started,
+      },
+    ];
+  let materialized: ReturnType<typeof materialize> | undefined;
+  try {
+    materialized = materialize(testCase, workbenchRoot);
+    const roots = [...walk(materialized.root)];
+    const targets = detectIntegrations(roots);
+    const projects: DetectedProject[] = roots.map((path, index) => ({
+      path: fixtureRelative(materialized!.root, path),
+      targetId: targets[index],
+      hasPostHog: hasPostHog(path),
+    }));
+    const report: DetectionReport = normalizeReport({
+      repoType: detectRepoType(materialized.root),
+      projects,
+    });
+    const mismatches: Mismatch[] = [];
+    if (consumer.expectedOutcome === "no-manifests" && projects.length !== 0)
+      mismatches.push({
+        field: "outcome",
+        severity: "error",
+        expected: "no-manifests",
+        actual: "success",
+        message: "manifest projects were detected",
+      });
+    if (consumer.expectedOutcome === "success" && projects.length === 0)
+      mismatches.push({
+        field: "outcome",
+        severity: "error",
+        expected: "success",
+        actual: "no-manifests",
+        message: "no manifest projects were detected",
+      });
+    mismatches.push(...compareReport(consumer, report));
+    return [
+      {
+        caseId: testCase.id,
+        profile: consumer.profile,
+        mode: "registry-crosscheck",
+        status: mismatches.some((item) => item.severity !== "warning")
+          ? "failed"
+          : "passed",
+        evidenceClass: "Deterministic integration-proven",
+        checks: {
+          schema: "passed",
+          discovery: mismatches.some((item) => item.field === "projectPresence")
+            ? "failed"
+            : "passed",
+          classification: mismatches.some(
+            (item) => item.field === "targetId" || item.field === "hasPostHog"
+          )
+            ? "failed"
+            : "passed",
+          recommendation: "skipped",
+          selection: "skipped",
+          liveEvidence: "blocked",
+        },
+        mismatches,
+        durationMs: Date.now() - started,
+      },
+    ];
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return [
+      {
+        caseId: testCase.id,
+        profile: consumer.profile,
+        mode: "registry-crosscheck",
+        status: "failed",
+        evidenceClass: "Deterministic integration-proven",
+        checks: { infrastructure: "failed" },
+        mismatches: [
+          {
+            field: "outcome",
+            severity: "critical",
+            expected: consumer.expectedOutcome,
+            actual: "infrastructure-error",
+            message,
+          },
+        ],
+        durationMs: Date.now() - started,
+      },
+    ];
+  } finally {
+    materialized?.cleanup();
+  }
+}
+
+/** Evaluate a corpus through one Wizard subprocess so detector timeout timers overlap. */
+export function runRegistryCases(
+  cases: DetectionCase[],
+  workbenchRoot: string
+): EvaluationResult[] {
+  const prepared: Array<{
+    testCase: DetectionCase;
+    consumer: ConsumerExpectation;
+    materialized: ReturnType<typeof materialize>;
+    roots: string[];
+    started: number;
+  }> = [];
+  const early: EvaluationResult[] = [];
+  try {
+    for (const testCase of cases) {
+      const consumer = testCase.consumers.find(
+        (item) => item.profile === "registry-crosscheck"
+      );
+      if (!consumer) continue;
+      const errors = validateTargets(testCase);
+      if (errors.length) {
+        early.push({
+          caseId: testCase.id,
+          profile: consumer.profile,
+          mode: "registry-crosscheck",
+          status: "failed",
+          evidenceClass: "Deterministic integration-proven",
+          checks: { schema: "failed" },
+          mismatches: errors.map((message) => ({
+            field: "schema",
+            severity: "critical",
+            expected: "production target",
+            actual: message,
+            message,
+          })),
+          durationMs: 0,
+        });
+        continue;
+      }
+      try {
+        const materialized = materialize(testCase, workbenchRoot);
+        prepared.push({
+          testCase,
+          consumer,
+          materialized,
+          roots: [...walk(materialized.root)],
+          started: Date.now(),
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        early.push({
+          caseId: testCase.id,
+          profile: consumer.profile,
+          mode: "registry-crosscheck",
+          status: "failed",
+          evidenceClass: "Deterministic integration-proven",
+          checks: { infrastructure: "failed" },
+          mismatches: [
+            {
+              field: "outcome",
+              severity: "critical",
+              expected: consumer.expectedOutcome,
+              actual: "infrastructure-error",
+              message,
+            },
+          ],
+          durationMs: 0,
+        });
+      }
+    }
+    const allRoots = prepared.flatMap((item) => item.roots);
+    const allTargets = detectIntegrations(allRoots);
+    let offset = 0;
+    const results = prepared.map(
+      ({ testCase, consumer, materialized, roots, started }) => {
+        const targets = allTargets.slice(offset, offset + roots.length);
+        offset += roots.length;
+        const projects: DetectedProject[] = roots.map((path, index) => ({
+          path: fixtureRelative(materialized.root, path),
+          targetId: targets[index],
+          hasPostHog: hasPostHog(path),
+        }));
+        const report = normalizeReport({
+          repoType: detectRepoType(materialized.root),
+          projects,
+        });
+        const mismatches: Mismatch[] = [];
+        if (consumer.expectedOutcome === "no-manifests" && projects.length)
+          mismatches.push({
+            field: "outcome",
+            severity: "error",
+            expected: "no-manifests",
+            actual: "success",
+            message: "manifest projects were detected",
+          });
+        if (consumer.expectedOutcome === "success" && !projects.length)
+          mismatches.push({
+            field: "outcome",
+            severity: "error",
+            expected: "success",
+            actual: "no-manifests",
+            message: "no manifest projects were detected",
+          });
+        mismatches.push(...compareReport(consumer, report));
+        return {
+          caseId: testCase.id,
+          profile: consumer.profile,
+          mode: "registry-crosscheck" as const,
+          status: mismatches.some((item) => item.severity !== "warning")
+            ? ("failed" as const)
+            : ("passed" as const),
+          evidenceClass: "Deterministic integration-proven" as const,
+          checks: {
+            schema: "passed" as const,
+            discovery: mismatches.some(
+              (item) => item.field === "projectPresence"
+            )
+              ? ("failed" as const)
+              : ("passed" as const),
+            classification: mismatches.some(
+              (item) => item.field === "targetId" || item.field === "hasPostHog"
+            )
+              ? ("failed" as const)
+              : ("passed" as const),
+            recommendation: "skipped" as const,
+            selection: "skipped" as const,
+            liveEvidence: "blocked" as const,
+          },
+          mismatches,
+          durationMs: Date.now() - started,
+        };
+      }
+    );
+    return [...early, ...results];
+  } finally {
+    for (const item of prepared) item.materialized.cleanup();
+  }
+}
+
+export function loadCases(directory: string): DetectionCase[] {
+  const cases = readdirSync(directory)
+    .filter((file) => file.endsWith(".json"))
+    .sort()
+    .map((file) =>
+      parseDetectionCase(
+        JSON.parse(readFileSync(join(directory, file), "utf8"))
+      )
+    );
+  validateCatalog(cases);
+  return cases;
+}
+
+export function expectation(
+  testCase: DetectionCase,
+  profile: ConsumerExpectation["profile"]
+): ConsumerExpectation | undefined {
+  return testCase.consumers.find((item) => item.profile === profile);
+}

--- a/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/apps/web/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/apps/web/package.json
@@ -1,0 +1,1 @@
+{ "name": "web", "private": true, "scripts": { "dev": "vite" }, "dependencies": { "react": "19.0.0", "react-dom": "19.0.0" }, "devDependencies": { "vite": "6.0.0" } }

--- a/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/package.json
@@ -1,0 +1,1 @@
+{ "name": "issue-113-npm", "private": true, "workspaces": ["apps/*", "workers/*"] }

--- a/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/workers/events/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-npm-vite-workers/workers/events/package.json
@@ -1,0 +1,1 @@
+{ "name": "events-worker", "private": true, "dependencies": { "fastify": "5.0.0" } }

--- a/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/apps/web/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/apps/web/package.json
@@ -1,0 +1,1 @@
+{ "name": "web", "private": true, "dependencies": { "next": "15.0.0", "react": "19.0.0", "react-dom": "19.0.0" } }

--- a/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/package.json
@@ -1,0 +1,1 @@
+{ "name": "issue-113-pnpm", "private": true, "workspaces": ["apps/*", "services/*"] }

--- a/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/pnpm-workspace.yaml
+++ b/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - apps/*
+  - services/*

--- a/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/services/api/package.json
+++ b/services/project-detection-eval/fixtures/issue-113-pnpm-next-api/services/api/package.json
@@ -1,0 +1,1 @@
+{ "name": "api", "private": true, "dependencies": { "express": "5.0.0" } }

--- a/services/project-detection-eval/fixtures/turbo-next-expo/apps/mobile/package.json
+++ b/services/project-detection-eval/fixtures/turbo-next-expo/apps/mobile/package.json
@@ -1,0 +1,1 @@
+{ "name": "mobile", "private": true, "dependencies": { "expo": "52.0.0", "react": "19.0.0", "react-native": "0.76.0" } }

--- a/services/project-detection-eval/fixtures/turbo-next-expo/apps/web/package.json
+++ b/services/project-detection-eval/fixtures/turbo-next-expo/apps/web/package.json
@@ -1,0 +1,1 @@
+{ "name": "web", "private": true, "dependencies": { "next": "15.0.0", "react": "19.0.0", "react-dom": "19.0.0" } }

--- a/services/project-detection-eval/fixtures/turbo-next-expo/package.json
+++ b/services/project-detection-eval/fixtures/turbo-next-expo/package.json
@@ -1,0 +1,1 @@
+{ "name": "turbo-next-expo", "private": true, "workspaces": ["apps/*"] }

--- a/services/project-detection-eval/fixtures/turbo-next-expo/pnpm-workspace.yaml
+++ b/services/project-detection-eval/fixtures/turbo-next-expo/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - apps/*

--- a/services/project-detection-eval/fixtures/turbo-next-expo/turbo.json
+++ b/services/project-detection-eval/fixtures/turbo-next-expo/turbo.json
@@ -1,0 +1,1 @@
+{ "tasks": { "build": { "dependsOn": ["^build"] } } }

--- a/services/project-detection-eval/index.ts
+++ b/services/project-detection-eval/index.ts
@@ -34,7 +34,8 @@ const outputDir = resolve(
       new Date().toISOString().replaceAll(/[:.]/g, "-")
     )
 );
-const wizardSource = sourceState(wizardPath());
+const wizardRoot = wizardPath();
+const wizardSource = sourceState(wizardRoot);
 const workbenchSource = sourceState(root);
 const cases = loadCases(join(import.meta.dirname, "cases")).filter(
   (item) => !caseId || item.id === caseId
@@ -60,10 +61,10 @@ const artifact: EvaluationArtifact = {
   results: runRegistryCases(cases, root),
 };
 
-writeArtifacts(outputDir, artifact);
+const sanitizedArtifact = writeArtifacts(outputDir, artifact, [wizardRoot]);
 console.log(
   json
-    ? JSON.stringify(artifact, null, 2)
+    ? JSON.stringify(sanitizedArtifact, null, 2)
     : `${artifact.results.filter((result) => result.status === "passed").length}/${artifact.results.length} checks passed\nArtifacts: ${outputDir}`
 );
 process.exitCode = evaluationExitCode(artifact);

--- a/services/project-detection-eval/index.ts
+++ b/services/project-detection-eval/index.ts
@@ -1,0 +1,69 @@
+#!/usr/bin/env node
+import { join, resolve } from "node:path";
+import { loadCases, runRegistryCases } from "./evaluator.js";
+import {
+  evaluationExitCode,
+  writeArtifacts,
+  type EvaluationArtifact,
+} from "./reporting/reporter.js";
+import { productionRuntime, wizardPath } from "./wizard-runner.js";
+import { sourceState } from "./source-state.js";
+
+function valueAfter(args: string[], name: string): string | undefined {
+  const index = args.indexOf(name);
+  return index === -1 ? undefined : args[index + 1];
+}
+
+const root = resolve(import.meta.dirname, "../..");
+const args = process.argv.slice(2);
+const json = args.includes("--json");
+const optionValues = new Set(
+  ["--case", "--output-dir"]
+    .map((name) => valueAfter(args, name))
+    .filter((value): value is string => value !== undefined)
+);
+const caseId =
+  valueAfter(args, "--case") ??
+  args.find((arg) => !arg.startsWith("--") && !optionValues.has(arg));
+const outputDir = resolve(
+  valueAfter(args, "--output-dir") ??
+    join(
+      root,
+      "artifacts",
+      "project-detection-eval",
+      new Date().toISOString().replaceAll(/[:.]/g, "-")
+    )
+);
+const wizardSource = sourceState(wizardPath());
+const workbenchSource = sourceState(root);
+const cases = loadCases(join(import.meta.dirname, "cases")).filter(
+  (item) => !caseId || item.id === caseId
+);
+if (!cases.length)
+  throw new Error(caseId ? `Unknown case: ${caseId}` : "No cases found");
+
+const artifact: EvaluationArtifact = {
+  schemaVersion: 1,
+  runId: `local-${Date.now()}`,
+  generatedAt: new Date().toISOString(),
+  mode: "registry-crosscheck",
+  wizardSha: wizardSource.sha,
+  workbenchSha: workbenchSource.sha,
+  wizardSource,
+  workbenchSource,
+  runtime: productionRuntime(),
+  reproductionCommand: `WIZARD_PATH="$WIZARD_REPO" pnpm project-detection-eval${
+    caseId ? ` --case ${caseId}` : ""
+  } --output-dir "$OUTPUT_DIR"`,
+  rawArtifactPath: "results.json",
+  liveClaims: "blocked-until-credentialed-isolated-run",
+  results: runRegistryCases(cases, root),
+};
+
+writeArtifacts(outputDir, artifact);
+console.log(
+  json
+    ? JSON.stringify(artifact, null, 2)
+    : `${artifact.results.filter((result) => result.status === "passed").length}/${artifact.results.length} checks passed\nArtifacts: ${outputDir}`
+);
+process.exitCode = evaluationExitCode(artifact);

--- a/services/project-detection-eval/index.ts
+++ b/services/project-detection-eval/index.ts
@@ -6,7 +6,7 @@ import {
   writeArtifacts,
   type EvaluationArtifact,
 } from "./reporting/reporter.js";
-import { productionRuntime, wizardPath } from "./wizard-runner.js";
+import { wizardPath } from "./wizard-runner.js";
 import { sourceState } from "./source-state.js";
 
 function valueAfter(args: string[], name: string): string | undefined {
@@ -52,7 +52,6 @@ const artifact: EvaluationArtifact = {
   workbenchSha: workbenchSource.sha,
   wizardSource,
   workbenchSource,
-  runtime: productionRuntime(),
   reproductionCommand: `WIZARD_PATH="$WIZARD_REPO" pnpm project-detection-eval${
     caseId ? ` --case ${caseId}` : ""
   } --output-dir "$OUTPUT_DIR"`,

--- a/services/project-detection-eval/reporting/redaction.ts
+++ b/services/project-detection-eval/reporting/redaction.ts
@@ -1,0 +1,34 @@
+import { homedir, tmpdir } from "node:os";
+import { relative, resolve, sep } from "node:path";
+
+const secret =
+  /((?:phc|phx|pha)_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+|(?:Bearer|Basic)\s+[A-Za-z0-9._~+/-]+=*)/gi;
+
+export function redactValue(value: unknown, fixtureRoot: string): unknown {
+  if (typeof value === "string") {
+    const absoluteRoot = resolve(fixtureRoot);
+    const contained = value.startsWith(absoluteRoot + sep)
+      ? relative(absoluteRoot, value).split(sep).join("/")
+      : value;
+    return contained
+      .replaceAll(absoluteRoot, "[FIXTURE]")
+      .replaceAll(homedir(), "[HOME]")
+      .replaceAll(resolve(tmpdir()), "[TMP]")
+      .replace(secret, "[REDACTED]");
+  }
+  if (Array.isArray(value))
+    return value.map((item) => redactValue(item, fixtureRoot));
+  if (value && typeof value === "object")
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>).map(([key, item]) => {
+        const sensitiveKey =
+          /secret|authorization|api.?key/i.test(key) ||
+          (/token/i.test(key) && typeof item === "string");
+        return [
+          key,
+          sensitiveKey ? "[REDACTED]" : redactValue(item, fixtureRoot),
+        ];
+      })
+    );
+  return value;
+}

--- a/services/project-detection-eval/reporting/redaction.ts
+++ b/services/project-detection-eval/reporting/redaction.ts
@@ -4,20 +4,30 @@ import { relative, resolve, sep } from "node:path";
 const secret =
   /((?:phc|phx|pha)_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]+|(?:Bearer|Basic)\s+[A-Za-z0-9._~+/-]+=*)/gi;
 
-export function redactValue(value: unknown, fixtureRoot: string): unknown {
+export function redactValue(
+  value: unknown,
+  fixtureRoot: string,
+  additionalRoots: string[] = []
+): unknown {
   if (typeof value === "string") {
     const absoluteRoot = resolve(fixtureRoot);
     const contained = value.startsWith(absoluteRoot + sep)
       ? relative(absoluteRoot, value).split(sep).join("/")
       : value;
-    return contained
+    const localRedacted = additionalRoots
+      .map((root) => resolve(root))
+      .sort((left, right) => right.length - left.length)
+      .reduce((text, root) => text.replaceAll(root, "[LOCAL]"), contained);
+    return localRedacted
       .replaceAll(absoluteRoot, "[FIXTURE]")
       .replaceAll(homedir(), "[HOME]")
       .replaceAll(resolve(tmpdir()), "[TMP]")
       .replace(secret, "[REDACTED]");
   }
   if (Array.isArray(value))
-    return value.map((item) => redactValue(item, fixtureRoot));
+    return value.map((item) =>
+      redactValue(item, fixtureRoot, additionalRoots)
+    );
   if (value && typeof value === "object")
     return Object.fromEntries(
       Object.entries(value as Record<string, unknown>).map(([key, item]) => {
@@ -26,7 +36,9 @@ export function redactValue(value: unknown, fixtureRoot: string): unknown {
           (/token/i.test(key) && typeof item === "string");
         return [
           key,
-          sensitiveKey ? "[REDACTED]" : redactValue(item, fixtureRoot),
+          sensitiveKey
+            ? "[REDACTED]"
+            : redactValue(item, fixtureRoot, additionalRoots),
         ];
       })
     );

--- a/services/project-detection-eval/reporting/reporter.ts
+++ b/services/project-detection-eval/reporting/reporter.ts
@@ -80,7 +80,7 @@ export function markdownSummary(artifact: EvaluationArtifact): string {
       lines.push(
         `- **${mismatch.severity} ${mismatch.field}${
           mismatch.projectPath ? ` (${inlineCode(mismatch.projectPath)})` : ""
-        }:** ${mismatch.message}; expected ${renderValue(
+        }:** ${inlineCode(mismatch.message)}; expected ${renderValue(
           mismatch.expected
         )}, received ${renderValue(mismatch.actual)}.`
       );
@@ -106,10 +106,15 @@ function renderValue(value: unknown): string {
 
 export function writeArtifacts(
   outputDir: string,
-  artifact: EvaluationArtifact
-): void {
+  artifact: EvaluationArtifact,
+  additionalRedactionRoots: string[] = []
+): EvaluationArtifact {
   mkdirSync(outputDir, { recursive: true });
-  const sanitized = redactValue(artifact, process.cwd()) as EvaluationArtifact;
+  const sanitized = redactValue(
+    artifact,
+    process.cwd(),
+    additionalRedactionRoots
+  ) as EvaluationArtifact;
   writeFileSync(
     join(outputDir, "results.json"),
     `${JSON.stringify(sanitized, null, 2)}\n`
@@ -118,6 +123,7 @@ export function writeArtifacts(
     join(outputDir, "summary.md"),
     `${markdownSummary(sanitized)}\n`
   );
+  return sanitized;
 }
 
 export function evaluationExitCode(artifact: EvaluationArtifact): 0 | 1 {

--- a/services/project-detection-eval/reporting/reporter.ts
+++ b/services/project-detection-eval/reporting/reporter.ts
@@ -13,7 +13,6 @@ export type EvaluationArtifact = {
   workbenchSha: string;
   wizardSource?: SourceState;
   workbenchSource?: SourceState;
-  runtime?: { model: string; agentSdk: string; harness: string };
   reproductionCommand: string;
   rawArtifactPath: "results.json";
   liveClaims: "blocked-until-credentialed-isolated-run";
@@ -46,11 +45,7 @@ export function markdownSummary(artifact: EvaluationArtifact): string {
       ""
     );
   }
-  if (artifact.runtime)
-    lines.push(
-      `Runtime: \`${artifact.runtime.model}\` via \`${artifact.runtime.harness}\` and Agent SDK \`${artifact.runtime.agentSdk}\`.`,
-      ""
-    );
+  lines.push("Executed runtime: deterministic Wizard framework registry.", "");
   lines.push(
     "> Live model accuracy, recommendation quality, observed tool discipline, latency/cost/stability, and production-path isolation remain blocked.",
     ""
@@ -75,6 +70,12 @@ export function markdownSummary(artifact: EvaluationArtifact): string {
       ""
     );
     lines.push(`Evidence: ${result.evidenceClass}.`, "");
+    if (result.fieldEvidence) {
+      lines.push("| Field | Evidence |", "| --- | --- |");
+      for (const [field, evidence] of Object.entries(result.fieldEvidence))
+        lines.push(`| ${field} | ${evidence} |`);
+      lines.push("");
+    }
     if (!result.mismatches.length) lines.push("No mismatches.", "");
     for (const mismatch of result.mismatches)
       lines.push(

--- a/services/project-detection-eval/reporting/reporter.ts
+++ b/services/project-detection-eval/reporting/reporter.ts
@@ -1,0 +1,126 @@
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import type { EvaluationResult } from "../types.js";
+import { redactValue } from "./redaction.js";
+import type { SourceState } from "../source-state.js";
+
+export type EvaluationArtifact = {
+  schemaVersion: 1;
+  runId: string;
+  generatedAt: string;
+  mode: "registry-crosscheck" | "simulated";
+  wizardSha: string;
+  workbenchSha: string;
+  wizardSource?: SourceState;
+  workbenchSource?: SourceState;
+  runtime?: { model: string; agentSdk: string; harness: string };
+  reproductionCommand: string;
+  rawArtifactPath: "results.json";
+  liveClaims: "blocked-until-credentialed-isolated-run";
+  results: EvaluationResult[];
+};
+
+export function markdownSummary(artifact: EvaluationArtifact): string {
+  const passed = artifact.results.filter(
+    (result) => result.status === "passed"
+  );
+  const failed = artifact.results.filter(
+    (result) => result.status === "failed"
+  );
+  const blocked = artifact.results.filter(
+    (result) => result.status === "blocked"
+  );
+  const lines = [
+    "# Project detection evaluation",
+    "",
+    `${artifact.results.length} checks: ${passed.length} passed, ${failed.length} failed, ${blocked.length} blocked.`,
+    "",
+    `Mode: \`${artifact.mode}\` · Wizard: \`${artifact.wizardSha}\` · Workbench: \`${artifact.workbenchSha}\``,
+    "",
+  ];
+  if (artifact.wizardSource?.dirty || artifact.workbenchSource?.dirty) {
+    lines.push(
+      `Local source: Wizard ${
+        artifact.wizardSource?.workingTreeDigest ?? "clean"
+      }; Workbench ${artifact.workbenchSource?.workingTreeDigest ?? "clean"}.`,
+      ""
+    );
+  }
+  if (artifact.runtime)
+    lines.push(
+      `Runtime: \`${artifact.runtime.model}\` via \`${artifact.runtime.harness}\` and Agent SDK \`${artifact.runtime.agentSdk}\`.`,
+      ""
+    );
+  lines.push(
+    "> Live model accuracy, recommendation quality, observed tool discipline, latency/cost/stability, and production-path isolation remain blocked.",
+    ""
+  );
+  lines.push(
+    `Reproduce: \`${artifact.reproductionCommand}\``,
+    "",
+    `Raw artifact: \`${artifact.rawArtifactPath}\``,
+    ""
+  );
+  for (const result of artifact.results) {
+    const label =
+      result.status === "passed"
+        ? "PASS"
+        : result.status === "blocked"
+        ? "BLOCKED"
+        : "FAIL";
+    lines.push(
+      `## ${label} ${result.caseId} / ${result.profile}${
+        result.attempt ? ` / attempt ${result.attempt}` : ""
+      }`,
+      ""
+    );
+    lines.push(`Evidence: ${result.evidenceClass}.`, "");
+    if (!result.mismatches.length) lines.push("No mismatches.", "");
+    for (const mismatch of result.mismatches)
+      lines.push(
+        `- **${mismatch.severity} ${mismatch.field}${
+          mismatch.projectPath ? ` (${inlineCode(mismatch.projectPath)})` : ""
+        }:** ${mismatch.message}; expected ${renderValue(
+          mismatch.expected
+        )}, received ${renderValue(mismatch.actual)}.`
+      );
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+function inlineCode(value: string): string {
+  const singleLine = value.replace(/[\r\n]+/g, " ");
+  const longest = Math.max(
+    0,
+    ...Array.from(singleLine.matchAll(/`+/g), (match) => match[0].length)
+  );
+  const fence = "`".repeat(longest + 1);
+  return `${fence} ${singleLine} ${fence}`;
+}
+
+function renderValue(value: unknown): string {
+  const serialized = JSON.stringify(value);
+  return inlineCode(serialized === undefined ? String(value) : serialized);
+}
+
+export function writeArtifacts(
+  outputDir: string,
+  artifact: EvaluationArtifact
+): void {
+  mkdirSync(outputDir, { recursive: true });
+  const sanitized = redactValue(artifact, process.cwd()) as EvaluationArtifact;
+  writeFileSync(
+    join(outputDir, "results.json"),
+    `${JSON.stringify(sanitized, null, 2)}\n`
+  );
+  writeFileSync(
+    join(outputDir, "summary.md"),
+    `${markdownSummary(sanitized)}\n`
+  );
+}
+
+export function evaluationExitCode(artifact: EvaluationArtifact): 0 | 1 {
+  if (artifact.results.some((result) => result.status !== "passed")) return 1;
+  return 0;
+}

--- a/services/project-detection-eval/runners/simulated.ts
+++ b/services/project-detection-eval/runners/simulated.ts
@@ -1,0 +1,21 @@
+import type { DetectionRun } from "../types.js";
+
+export type SimulatedResponse = Omit<DetectionRun, "mode">;
+
+/** Scripted runner for evaluator tests. It is never production detector evidence. */
+export class SimulatedRunner {
+  readonly mode = "simulated" as const;
+  constructor(private readonly responses: Map<string, SimulatedResponse>) {}
+  run(caseId: string): DetectionRun {
+    const response = this.responses.get(caseId);
+    if (!response)
+      return {
+        mode: this.mode,
+        status: "infrastructure-error",
+        toolCalls: [],
+        durationMs: 0,
+        error: `missing simulated response: ${caseId}`,
+      };
+    return { mode: this.mode, ...structuredClone(response) };
+  }
+}

--- a/services/project-detection-eval/schema.ts
+++ b/services/project-detection-eval/schema.ts
@@ -1,0 +1,173 @@
+import { z } from "zod";
+import { posix, win32 } from "node:path";
+import type { DetectionCase, DetectionReport } from "./types.js";
+
+const safeRelativePath = z
+  .string()
+  .min(1)
+  .refine(
+    (value) => !/[\u0000-\u001f\u007f]/.test(value),
+    "path must not contain control characters"
+  )
+  .refine(
+    (value) =>
+      value === "." ||
+      (!posix.isAbsolute(value.replaceAll("\\", "/")) &&
+        !win32.isAbsolute(value) &&
+        !value.split(/[\\/]/).includes("..")),
+    "path must be fixture-relative and contained"
+  );
+const nonEmptyStrings = z.array(z.string().min(1)).min(1);
+
+const project = z
+  .object({
+    path: safeRelativePath,
+    presence: z.enum(["required", "optional", "forbidden"]),
+    role: z
+      .enum([
+        "workspace-root",
+        "client",
+        "server",
+        "library",
+        "docs",
+        "tooling",
+      ])
+      .optional(),
+    canonicalFramework: z.string().min(1).optional(),
+    acceptedLabels: nonEmptyStrings.optional(),
+    targetId: z.string().min(1).nullable().optional(),
+    hasPostHog: z.boolean().optional(),
+  })
+  .strict();
+
+const recommendation = z
+  .object({
+    required: z.boolean(),
+    acceptablePaths: z.array(safeRelativePath).min(1),
+    forbiddenPaths: z.array(safeRelativePath).optional(),
+    rationale: z.string().min(1),
+  })
+  .strict();
+
+const consumer = z
+  .object({
+    profile: z.enum([
+      "registry-crosscheck",
+      "self-driving-integration",
+      "source-maps",
+      "headless-integration",
+    ]),
+    expectedOutcome: z.enum([
+      "success",
+      "no-manifests",
+      "no-supported-project",
+      "fallback",
+      "detector-error",
+    ]),
+    repoType: z.enum(["single", "monorepo"]).optional(),
+    projects: z.array(project).optional(),
+    recommendation: recommendation.optional(),
+    selectedPath: z
+      .object({
+        acceptablePaths: z.array(safeRelativePath).min(1),
+        expectedStrategy: z.enum([
+          "user-choice",
+          "recommended",
+          "first-instrumentable",
+          "none-fallback",
+        ]),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const paths = value.projects?.map((item) => item.path) ?? [];
+    for (const duplicate of paths.filter(
+      (path, index) => paths.indexOf(path) !== index
+    ))
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate project path: ${duplicate}`,
+        path: ["projects"],
+      });
+  });
+
+export const detectionCaseSchema = z
+  .object({
+    schemaVersion: z.literal(1),
+    id: z.string().regex(/^[a-z0-9][a-z0-9-]*$/),
+    description: z.string().min(1),
+    provenance: z
+      .object({
+        reason: z.string().min(1),
+        issueUrls: z.array(z.string().url()).optional(),
+        prUrls: z.array(z.string().url()).optional(),
+        customerPattern: z.string().min(1).optional(),
+      })
+      .strict(),
+    fixture: z
+      .object({
+        kind: z.enum(["synthetic", "workbench-app", "submodule"]),
+        path: safeRelativePath,
+        copyBeforeRun: z.boolean(),
+      })
+      .strict(),
+    tiers: z.array(z.enum(["pr", "nightly", "experimental"])).min(1),
+    consumers: z.array(consumer).min(1),
+    tags: nonEmptyStrings,
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const profiles = value.consumers.map((item) => item.profile);
+    for (const duplicate of profiles.filter(
+      (profile, index) => profiles.indexOf(profile) !== index
+    )) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `duplicate consumer profile: ${duplicate}`,
+        path: ["consumers"],
+      });
+    }
+  });
+
+export const detectionReportSchema = z
+  .object({
+    repoType: z.enum(["single", "monorepo"]),
+    projects: z.array(
+      z
+        .object({
+          path: safeRelativePath,
+          framework: z.string().min(1).optional(),
+          targetId: z.string().min(1).nullable(),
+          hasPostHog: z.boolean(),
+          recommended: z.boolean().optional(),
+        })
+        .strict()
+    ),
+    selectedPath: safeRelativePath.nullable().optional(),
+    selectedStrategy: z
+      .enum([
+        "user-choice",
+        "recommended",
+        "first-instrumentable",
+        "none-fallback",
+      ])
+      .optional(),
+  })
+  .strict();
+
+export function parseDetectionCase(value: unknown): DetectionCase {
+  return detectionCaseSchema.parse(value) as DetectionCase;
+}
+export function parseDetectionReport(value: unknown): DetectionReport {
+  return detectionReportSchema.parse(value) as DetectionReport;
+}
+
+export function validateCatalog(cases: DetectionCase[]): void {
+  const ids = new Set<string>();
+  for (const item of cases) {
+    if (ids.has(item.id)) throw new Error(`duplicate case id: ${item.id}`);
+    ids.add(item.id);
+  }
+}

--- a/services/project-detection-eval/source-state.ts
+++ b/services/project-detection-eval/source-state.ts
@@ -1,0 +1,133 @@
+import { createHash } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import { existsSync, lstatSync, readFileSync, readlinkSync } from "node:fs";
+import { basename, join, resolve, sep } from "node:path";
+
+export type SourceState = {
+  sha: string;
+  dirty: boolean;
+  workingTreeDigest?: string;
+};
+
+function git(cwd: string, args: string[]): Buffer {
+  return execFileSync("git", args, {
+    cwd,
+    encoding: "buffer",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function sensitiveSourcePath(path: string): boolean {
+  const normalized = path.replaceAll("\\", "/").toLowerCase();
+  const name = basename(path).toLowerCase();
+  return (
+    /^\.env(?:\.|$)/.test(name) ||
+    [
+      ".npmrc",
+      ".pypirc",
+      ".netrc",
+      "credentials.json",
+      "id_rsa",
+      "id_ed25519",
+    ].includes(name) ||
+    /\.(?:key|pem|p12|pfx)$/.test(name) ||
+    /(?:^|\/)\.ssh\//.test(normalized) ||
+    /(?:^|\/)\.aws\/(?:credentials|config)$/.test(normalized) ||
+    /(?:^|\/)\.(?:docker\/config\.json|kube\/config)$/.test(normalized) ||
+    /service[-_]account.*\.json$/.test(name)
+  );
+}
+
+/** Hash local paths without following symlinks or reading secret-named files. */
+function sourcePathDigest(
+  cwd: string,
+  paths: string[],
+  kind: "tracked" | "untracked"
+): Buffer {
+  const hash = createHash("sha256");
+  const root = resolve(cwd);
+  for (const path of [...paths].sort()) {
+    const fullPath = resolve(root, path);
+    if (fullPath !== root && !fullPath.startsWith(root + sep))
+      throw new Error(`source path escapes repository: ${path}`);
+    hash.update(`\0${kind}\0`);
+    hash.update(path);
+    hash.update("\0");
+    if (sensitiveSourcePath(path)) {
+      hash.update("sensitive-content-excluded");
+    } else {
+      try {
+        const stat = lstatSync(fullPath);
+        hash.update(`mode:${stat.mode}\0`);
+        if (stat.isSymbolicLink()) {
+          hash.update("symlink\0");
+          hash.update(readlinkSync(fullPath));
+        } else if (stat.isFile()) {
+          hash.update(readFileSync(fullPath));
+        } else if (stat.isDirectory() && existsSync(join(fullPath, ".git"))) {
+          hash.update("gitlink\0");
+          hash.update(git(fullPath, ["rev-parse", "HEAD"]));
+        } else {
+          hash.update("unsupported-entry");
+        }
+      } catch (error) {
+        const code = (error as NodeJS.ErrnoException).code;
+        if (code !== "ENOENT") throw error;
+        hash.update("deleted");
+      }
+    }
+  }
+  return hash.digest();
+}
+
+export function untrackedSourceDigest(cwd: string, paths: string[]): Buffer {
+  return sourcePathDigest(cwd, paths, "untracked");
+}
+
+export function trackedSourceDigest(cwd: string, paths: string[]): Buffer {
+  return sourcePathDigest(cwd, paths, "tracked");
+}
+
+/** Identify both the committed baseline and any local code evaluated on top. */
+export function sourceState(cwd: string): SourceState {
+  const sha = git(cwd, ["rev-parse", "HEAD"]).toString("utf8").trim();
+  const status = git(cwd, [
+    "status",
+    "--porcelain=v1",
+    "-z",
+    "--untracked-files=all",
+  ]);
+  if (status.length === 0) return { sha, dirty: false };
+
+  const hash = createHash("sha256");
+  hash.update(status);
+  const tracked = git(cwd, [
+    "diff",
+    "--name-only",
+    "-z",
+    "--no-renames",
+    "--no-ext-diff",
+    "HEAD",
+    "--",
+  ])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean);
+  hash.update(trackedSourceDigest(cwd, tracked));
+  const untracked = git(cwd, [
+    "ls-files",
+    "--others",
+    "--exclude-standard",
+    "-z",
+  ])
+    .toString("utf8")
+    .split("\0")
+    .filter(Boolean)
+    .sort();
+  hash.update(untrackedSourceDigest(cwd, untracked));
+  return {
+    sha,
+    dirty: true,
+    workingTreeDigest: `sha256:${hash.digest("hex")}`,
+  };
+}

--- a/services/project-detection-eval/types.ts
+++ b/services/project-detection-eval/types.ts
@@ -137,13 +137,14 @@ export type EvaluationResult = {
   status: "passed" | "failed" | "blocked";
   evidenceClass:
     | "Unit-proven"
-    | "Deterministic integration-proven"
+    | "Mixed deterministic evidence"
     | "Recorded/replay-proven"
     | "Live agentic-proven"
     | "Human-reviewed"
     | "Inferred"
     | "Blocked"
     | "Unknown";
+  fieldEvidence?: Record<string, string>;
   checks: Record<string, CheckState>;
   mismatches: Mismatch[];
   durationMs: number;

--- a/services/project-detection-eval/types.ts
+++ b/services/project-detection-eval/types.ts
@@ -1,0 +1,150 @@
+export type EvaluationMode = "registry-crosscheck" | "simulated";
+export type ConsumerProfile =
+  | "registry-crosscheck"
+  | "self-driving-integration"
+  | "source-maps"
+  | "headless-integration";
+export type ExpectedOutcome =
+  | "success"
+  | "no-manifests"
+  | "no-supported-project"
+  | "fallback"
+  | "detector-error";
+export type CheckState =
+  | "passed"
+  | "failed"
+  | "warning"
+  | "skipped"
+  | "blocked";
+
+export type ProjectExpectation = {
+  path: string;
+  presence: "required" | "optional" | "forbidden";
+  role?:
+    | "workspace-root"
+    | "client"
+    | "server"
+    | "library"
+    | "docs"
+    | "tooling";
+  canonicalFramework?: string;
+  acceptedLabels?: string[];
+  targetId?: string | null;
+  hasPostHog?: boolean;
+};
+
+export type RecommendationExpectation = {
+  required: boolean;
+  acceptablePaths: string[];
+  forbiddenPaths?: string[];
+  rationale: string;
+};
+
+export type ConsumerExpectation = {
+  profile: ConsumerProfile;
+  expectedOutcome: ExpectedOutcome;
+  repoType?: "single" | "monorepo";
+  projects?: ProjectExpectation[];
+  recommendation?: RecommendationExpectation;
+  selectedPath?: {
+    acceptablePaths: string[];
+    expectedStrategy:
+      | "user-choice"
+      | "recommended"
+      | "first-instrumentable"
+      | "none-fallback";
+  };
+};
+
+export type DetectionCase = {
+  schemaVersion: 1;
+  id: string;
+  description: string;
+  provenance: {
+    reason: string;
+    issueUrls?: string[];
+    prUrls?: string[];
+    customerPattern?: string;
+  };
+  fixture: {
+    kind: "synthetic" | "workbench-app" | "submodule";
+    path: string;
+    copyBeforeRun: boolean;
+  };
+  tiers: Array<"pr" | "nightly" | "experimental">;
+  consumers: ConsumerExpectation[];
+  tags: string[];
+};
+
+export type ToolCall = {
+  tool: string;
+  input: Record<string, unknown>;
+  sequence: number;
+};
+export type DetectedProject = {
+  path: string;
+  framework?: string;
+  targetId: string | null;
+  hasPostHog: boolean;
+  recommended?: boolean;
+};
+export type DetectionReport = {
+  repoType: "single" | "monorepo";
+  projects: DetectedProject[];
+  selectedPath?: string | null;
+  selectedStrategy?:
+    | "user-choice"
+    | "recommended"
+    | "first-instrumentable"
+    | "none-fallback";
+};
+export type DetectionRun = {
+  mode: EvaluationMode;
+  status: "completed" | "detector-error" | "infrastructure-error" | "timeout";
+  report?: DetectionReport;
+  toolCalls: ToolCall[];
+  durationMs: number;
+  error?: string;
+};
+
+export type Mismatch = {
+  field:
+    | "outcome"
+    | "repoType"
+    | "projectPresence"
+    | "manifestGrounding"
+    | "framework"
+    | "targetId"
+    | "hasPostHog"
+    | "recommendation"
+    | "selectedPath"
+    | "selectedStrategy"
+    | "toolPolicy"
+    | "pathContainment"
+    | "schema";
+  severity: "critical" | "error" | "warning";
+  projectPath?: string;
+  expected: unknown;
+  actual: unknown;
+  message: string;
+};
+
+export type EvaluationResult = {
+  caseId: string;
+  attempt?: number;
+  profile: ConsumerProfile;
+  mode: EvaluationMode;
+  status: "passed" | "failed" | "blocked";
+  evidenceClass:
+    | "Unit-proven"
+    | "Deterministic integration-proven"
+    | "Recorded/replay-proven"
+    | "Live agentic-proven"
+    | "Human-reviewed"
+    | "Inferred"
+    | "Blocked"
+    | "Unknown";
+  checks: Record<string, CheckState>;
+  mismatches: Mismatch[];
+  durationMs: number;
+};

--- a/services/project-detection-eval/wizard-runner.ts
+++ b/services/project-detection-eval/wizard-runner.ts
@@ -70,31 +70,6 @@ export function productionTargets(profile: TargetProfile): string[] {
   return targets;
 }
 
-export function productionRuntime(): {
-  model: string;
-  agentSdk: string;
-  harness: string;
-} {
-  const cwd = wizardPath();
-  const tsx = join(cwd, "node_modules", ".bin", "tsx");
-  const script = String.raw`
-const { HAIKU_MODEL } = require('./src/lib/constants');
-const packageJson = require('./package.json');
-console.log(JSON.stringify({ model: HAIKU_MODEL, agentSdk: packageJson.dependencies['@anthropic-ai/claude-agent-sdk'], harness: 'wizard-detectProjectsWithAgent' }));
-`;
-  const output = execFileSync(tsx, ["-e", script], {
-    cwd,
-    encoding: "utf8",
-    timeout: 30_000,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-  return JSON.parse(output.trim().split("\n").at(-1) ?? "null") as {
-    model: string;
-    agentSdk: string;
-    harness: string;
-  };
-}
-
 export function detectIntegration(path: string): string | null {
   return invoke("integration", "detect", path) as string | null;
 }

--- a/services/project-detection-eval/wizard-runner.ts
+++ b/services/project-detection-eval/wizard-runner.ts
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+type TargetProfile = "integration" | "source-maps";
+
+const SCRIPT = String.raw`
+const profile = process.argv[1];
+const command = process.argv[2];
+async function main() {
+  if (command === 'manifest-glob') {
+    const { manifestGlob } = require('./src/lib/detection/agentic');
+    console.log(JSON.stringify(manifestGlob()));
+    return;
+  }
+  if (command === 'targets') {
+    if (profile === 'integration') {
+      const { FRAMEWORK_REGISTRY } = require('./src/lib/registry');
+      console.log(JSON.stringify(Object.keys(FRAMEWORK_REGISTRY)));
+    } else {
+      const { AUTOMATABLE_VARIANTS } = require('./src/lib/programs/error-tracking-upload-source-maps/detect');
+      console.log(JSON.stringify([...AUTOMATABLE_VARIANTS]));
+    }
+    return;
+  }
+  const installDir = process.argv[3];
+  const { detectFramework } = require('./src/lib/detection/framework');
+  if (command === 'detect-many') {
+    const paths = JSON.parse(installDir);
+    const results = [];
+    for (const path of paths) results.push((await detectFramework(path)) ?? null);
+    console.log(JSON.stringify(results));
+  } else {
+    const detected = await detectFramework(installDir);
+    console.log(JSON.stringify(detected ?? null));
+  }
+}
+main().catch((error) => { console.error(error); process.exit(1); });
+`;
+
+export function wizardPath(): string {
+  const raw = process.env.WIZARD_PATH;
+  if (!raw) throw new Error("WIZARD_PATH is required");
+  return raw.startsWith("~") ? raw.replace("~", homedir()) : raw;
+}
+
+function invoke(profile: TargetProfile, command: string, value = ""): unknown {
+  const cwd = wizardPath();
+  const tsx = join(cwd, "node_modules", ".bin", "tsx");
+  if (!existsSync(join(cwd, "src", "lib", "registry.ts")) || !existsSync(tsx)) {
+    throw new Error(
+      `Wizard source or installed dependencies are missing at ${cwd}`
+    );
+  }
+  const output = execFileSync(tsx, ["-e", SCRIPT, profile, command, value], {
+    cwd,
+    encoding: "utf8",
+    timeout: 30_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(output.trim().split("\n").at(-1) ?? "null");
+}
+
+const targetCache = new Map<TargetProfile, string[]>();
+export function productionTargets(profile: TargetProfile): string[] {
+  const cached = targetCache.get(profile);
+  if (cached) return cached;
+  const targets = invoke(profile, "targets") as string[];
+  targetCache.set(profile, targets);
+  return targets;
+}
+
+export function productionRuntime(): {
+  model: string;
+  agentSdk: string;
+  harness: string;
+} {
+  const cwd = wizardPath();
+  const tsx = join(cwd, "node_modules", ".bin", "tsx");
+  const script = String.raw`
+const { HAIKU_MODEL } = require('./src/lib/constants');
+const packageJson = require('./package.json');
+console.log(JSON.stringify({ model: HAIKU_MODEL, agentSdk: packageJson.dependencies['@anthropic-ai/claude-agent-sdk'], harness: 'wizard-detectProjectsWithAgent' }));
+`;
+  const output = execFileSync(tsx, ["-e", script], {
+    cwd,
+    encoding: "utf8",
+    timeout: 30_000,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  return JSON.parse(output.trim().split("\n").at(-1) ?? "null") as {
+    model: string;
+    agentSdk: string;
+    harness: string;
+  };
+}
+
+export function detectIntegration(path: string): string | null {
+  return invoke("integration", "detect", path) as string | null;
+}
+
+export function detectIntegrations(paths: string[]): Array<string | null> {
+  return invoke("integration", "detect-many", JSON.stringify(paths)) as Array<
+    string | null
+  >;
+}


### PR DESCRIPTION
## Problem

Relates to PostHog/wizard#716.

Wizard project detection has no versioned regression cases or field-level failure report. The existing `framework-detect` command is useful for interactive debugging, but it does not validate fixtures, expected project structure, or evaluator behavior.

## Changes

- Add a schema-validated case catalog and three focused monorepo fixtures.
- Compare project presence, repository type, target classification, PostHog presence, recommendation, selection, containment, and tool policy at field level.
- Cross-check target IDs against the evaluated Wizard checkout instead of duplicating registry values.
- Add simulated contracts for mismatches, timeouts, recommendation, selection, and forbidden tools.
- Write redacted JSON and Markdown reports with exact source fingerprints and reproduction commands.
- Preserve detector exceptions and result-count errors as structured infrastructure failures.

## Design

This is a sibling service rather than an expansion of `framework-detect`. The debugger stays lightweight; the evaluator owns schemas, fixtures, comparison, and durable reports.

Expectations live in a central catalog rather than beside every app. That keeps the contract queryable and also works for externally owned apps and submodules that should not receive evaluator metadata.

This evaluator includes simulated contract coverage for the optional `recommended` field proposed in PostHog/wizard#884; it does not validate or modify that PR's live model behavior.

Example output:

```text
3 checks: 3 passed, 0 failed, 0 blocked.
Mode: registry-crosscheck

## PASS issue-113-pnpm-next-api / registry-crosscheck
Evidence: Deterministic integration-proven.
No mismatches.
```

## Test plan

- `pnpm test:project-detection-eval` — 50/50 passed on macOS and Ubuntu 24.04 with Node 24.
- `pnpm typecheck:project-detection-eval` — passed with strict TypeScript settings on both platforms.
- `WIZARD_PATH="$WIZARD_REPO" pnpm project-detection-eval --output-dir "$OUTPUT_DIR"` — 0/3 against current clean Wizard main `b38091d8`; each case returned the evaluator’s structured infrastructure failure because the registry path changed upstream.
- Deliberate wrong-result mutation — three field-level `targetId` failures and exit 1.
- Deliberate throwing-detector mutation — three structured infrastructure failures, sanitized stdout matched `results.json`, and exit 1.

## Security and privacy

- This slice makes no model or gateway request and needs no credential.
- Fixtures run from throwaway copies where configured.
- Fixture and reported paths are containment-checked.
- Persisted output and `--json` stdout use the same sanitized artifact.
- Reports redact secret-shaped values, home paths, temporary paths, fixture paths, and the selected Wizard checkout path.
- Model-controlled paths and detector error messages cannot inject Markdown into summaries.

## Non-goals

- Real model-backed accuracy or recommendation quality.
- Production diagnostics or analytics isolation.
- Automatic CI promotion or a required check.
- Changes to Wizard production behavior.

Those remain separate follow-ups so the schema and fixture contract can be reviewed first.

## Reviewer questions

1. Is a sibling Workbench service the right ownership boundary for this evaluator?
2. Are these three fixtures the right minimum contract before adding the remaining corpus and production-path runner?