### PR TITLE
fix(ci): start Redis before the MCP server; fail fast when MCP never comes up

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -606,6 +606,23 @@ jobs:
             echo "::warning::Context Mill server failed to start after 2 minutes"
           fi
 
+          # The MCP hono server hard-exits without Redis (posthog services/mcp
+          # requires redis at localhost:6379) — start one before it.
+          if command -v docker > /dev/null 2>&1; then
+            docker run -d --name wizard-ci-redis -p 6379:6379 redis:7-alpine
+          elif command -v brew > /dev/null 2>&1; then
+            brew install redis > /dev/null 2>&1 || true
+            redis-server --daemonize yes
+          else
+            sudo apt-get install -y redis-server > /dev/null 2>&1 && sudo service redis-server start
+          fi
+          for i in {1..30}; do
+            if (echo PING | (command -v redis-cli > /dev/null 2>&1 && redis-cli 2>/dev/null || nc -w1 localhost 6379) | grep -q PONG); then
+              echo "Redis is ready"; break
+            fi
+            sleep 1
+          done
+
           # Start MCP server in background (consumes from local examples server)
           cd $MCP_PATH
           pnpm dev:local-resources &
@@ -629,7 +646,10 @@ jobs:
             fi
           done
           if [ "$MCP_READY" = "false" ]; then
-            echo "::warning::MCP server failed to start after 2 minutes"
+            # Fail fast: without the MCP the dashboard task fails in every app,
+            # burning a full agent run per matrix cell to report an infra outage.
+            echo "::error::MCP server failed to start after 2 minutes — infra failure, not a wizard failure"
+            exit 1
           fi
 
           echo "mcp_pid=$MCP_PID" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Every wizard-ci cell has been failing since posthog master's MCP hono server began hard-exiting without Redis (`[MCP] Failed to connect to Redis … process.exit(1)` at services/mcp/src/hono/index.ts). The workflow never started one, the readiness loop only warned, and each matrix cell then ran a full agent that failed at the dashboard task — ~40 wasted LLM runs per trigger reporting an infra outage as wizard failures.

Two changes in the Run Wizard CI step: start Redis before the MCP server (docker on ubuntu, brew fallback on the macos/swift runner, apt as last resort), and make the 2-minute MCP readiness timeout a hard `::error` + exit 1.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*