### PR TITLE
feat(ci): hit the prod MCP; drop the local posthog MCP server entirely

### DIFF
--- a/.github/actions/setup-wizard-deps/action.yml
+++ b/.github/actions/setup-wizard-deps/action.yml
@@ -9,6 +9,7 @@ inputs:
     description: 'Context Mill repo branch/tag/sha'
     required: true
   posthog_ref:
+    # Deprecated: the posthog MCP is no longer built locally (CI hits prod MCP).
     description: 'PostHog repo branch/tag/sha (for MCP)'
     required: true
   app_token:
@@ -54,14 +55,11 @@ runs:
         }
         WIZARD_SHA=$(resolve_sha wizard "$WIZARD_REF")
         CONTEXT_MILL_SHA=$(resolve_sha context-mill "$CONTEXT_MILL_REF")
-        POSTHOG_SHA=$(resolve_sha posthog "$POSTHOG_REF")
         echo "wizard_sha=$WIZARD_SHA" >> "$GITHUB_OUTPUT"
         echo "context_mill_sha=$CONTEXT_MILL_SHA" >> "$GITHUB_OUTPUT"
-        echo "posthog_sha=$POSTHOG_SHA" >> "$GITHUB_OUTPUT"
         echo "Resolved SHAs:"
         echo "  wizard ($WIZARD_REF) -> $WIZARD_SHA"
         echo "  context-mill ($CONTEXT_MILL_REF) -> $CONTEXT_MILL_SHA"
-        echo "  posthog ($POSTHOG_REF) -> $POSTHOG_SHA"
 
     # ------------------------------------------------------------------ wizard
     - name: Restore wizard cache
@@ -172,55 +170,3 @@ runs:
       shell: bash
       run: echo "CONTEXT_MILL_PATH=$HOME/context-mill" >> "$GITHUB_ENV"
 
-    # ----------------------------------------------------------- posthog (MCP)
-    - name: Restore posthog cache
-      id: cache-posthog
-      uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: ~/posthog
-        key: posthog-${{ runner.os }}-${{ steps.resolve.outputs.posthog_sha }}
-
-    - name: Build PostHog MCP
-      if: steps.cache-posthog.outputs.cache-hit != 'true'
-      shell: bash
-      env:
-        POSTHOG_SHA: ${{ steps.resolve.outputs.posthog_sha }}
-      run: |
-        echo "::group::Fetching PostHog monorepo at $POSTHOG_SHA"
-        rm -rf "$HOME/posthog"
-        git init -q "$HOME/posthog"
-        cd "$HOME/posthog"
-        git remote add origin https://github.com/PostHog/posthog.git
-        git fetch --depth 1 origin "$POSTHOG_SHA"
-        git checkout -q FETCH_HEAD
-        echo "::endgroup::"
-
-        echo "::group::Installing MCP dependencies (filtered to @posthog/mcp)"
-        # The monorepo is cloned solely to build services/mcp, so install only
-        # that package and its workspace dependencies. A full-workspace install
-        # also fetches and compiles unrelated native addons from plugin-server
-        # (lz4, node-rdkafka), which @posthog/mcp does not use and which break
-        # node-gyp on a cold cache (gyp_main.py "Permission denied", make Error
-        # 126) — the recurring "flaky install" failure. The trailing "..."
-        # selects @posthog/mcp plus its workspace deps and nothing else.
-        pnpm install --frozen-lockfile --filter "@posthog/mcp..."
-        echo "::endgroup::"
-
-        echo "::group::Building MCP UI apps"
-        cd "$HOME/posthog/services/mcp"
-        pnpm build
-        echo "::endgroup::"
-
-        # Drop the .git dir before caching — not needed to run, just bloat.
-        rm -rf "$HOME/posthog/.git"
-
-    - name: Save posthog cache
-      if: inputs.save_cache == 'true' && steps.cache-posthog.outputs.cache-hit != 'true'
-      uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
-      with:
-        path: ~/posthog
-        key: posthog-${{ runner.os }}-${{ steps.resolve.outputs.posthog_sha }}
-
-    - name: Export MCP_PATH
-      shell: bash
-      run: echo "MCP_PATH=$HOME/posthog/services/mcp" >> "$GITHUB_ENV"

--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -555,10 +555,10 @@ jobs:
           fi
 
       - name: Setup wizard dependencies
-        # Restores wizard / context-mill / MCP from the cache warmed by the
+        # Restores wizard / context-mill from the cache warmed by the
         # setup-deps job (keyed on each repo's resolved commit SHA), falling
         # back to a clean build on a miss (e.g. macOS runners, cache eviction).
-        # Exports WIZARD_PATH / CONTEXT_MILL_PATH / MCP_PATH.
+        # Exports WIZARD_PATH / CONTEXT_MILL_PATH.
         uses: ./.github/actions/setup-wizard-deps
         with:
           wizard_ref: ${{ needs.discover.outputs.input_wizard_ref }}
@@ -606,33 +606,10 @@ jobs:
             echo "::warning::Context Mill server failed to start after 2 minutes"
           fi
 
-          # Start MCP server in background (consumes from local examples server)
-          cd $MCP_PATH
-          pnpm dev:local-resources &
-          MCP_PID=$!
-          disown $MCP_PID
+          # The posthog MCP is the hosted prod server — no local MCP process.
+          # MCP_URL overrides the wizard's local-mcp MCP half; skills stay local.
+          echo "MCP_URL=https://mcp.posthog.com/mcp" >> $GITHUB_ENV
 
-          # Wait for MCP server to be ready (retry every 30s, max 2 minutes)
-          echo "Waiting for MCP server to start..."
-          MCP_READY=false
-          for attempt in 1 2 3 4; do
-            for i in {1..30}; do
-              if curl -s http://localhost:8787/mcp > /dev/null 2>&1; then
-                echo "MCP server is ready"
-                MCP_READY=true
-                break 2
-              fi
-              sleep 1
-            done
-            if [ "$attempt" -lt 4 ]; then
-              echo "::warning::MCP server not ready after $((attempt * 30))s, retrying..."
-            fi
-          done
-          if [ "$MCP_READY" = "false" ]; then
-            echo "::warning::MCP server failed to start after 2 minutes"
-          fi
-
-          echo "mcp_pid=$MCP_PID" >> $GITHUB_OUTPUT
           echo "context_mill_pid=$CONTEXT_MILL_PID" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
@@ -642,7 +619,6 @@ jobs:
           # Dependency paths
           WIZARD_PATH: ${{ env.WIZARD_PATH }}
           CONTEXT_MILL_PATH: ${{ env.CONTEXT_MILL_PATH }}
-          MCP_PATH: ${{ env.MCP_PATH }}
           # Dependency refs (for PR body)
           WIZARD_REF: ${{ needs.discover.outputs.input_wizard_ref }}
           CONTEXT_MILL_REF: ${{ needs.discover.outputs.input_context_mill_ref }}
@@ -689,7 +665,6 @@ jobs:
           POSTHOG_WIZARD_PROJECT_ID: ${{ secrets.GH_APP_POSTHOG_WIZARD_CI_BOT_TARGET_PROJECT_ID }}
           WIZARD_PATH: ${{ env.WIZARD_PATH }}
           CONTEXT_MILL_PATH: ${{ env.CONTEXT_MILL_PATH }}
-          MCP_PATH: ${{ env.MCP_PATH }}
           WIZARD_REF: ${{ needs.discover.outputs.input_wizard_ref }}
           CONTEXT_MILL_REF: ${{ needs.discover.outputs.input_context_mill_ref }}
           POSTHOG_REF: ${{ needs.discover.outputs.input_posthog_ref }}
@@ -710,7 +685,6 @@ jobs:
           curl -s http://localhost:8765/skills-mcp-resources.zip -o skills-mcp-resources.zip || true
 
           # Stop servers
-          kill "$MCP_PID" 2>/dev/null || true
           kill "$CONTEXT_MILL_PID" 2>/dev/null || true
 
           # Extract PR URL
@@ -766,7 +740,6 @@ jobs:
         env:
           WIZARD_OUTCOME: ${{ steps.execute-wizard.outcome }}
           MATRIX_APP: ${{ matrix.app }}
-          MCP_PID: ${{ steps.run-wizard.outputs.mcp_pid }}
           CONTEXT_MILL_PID: ${{ steps.run-wizard.outputs.context_mill_pid }}
 
       - name: Configure AWS credentials
@@ -825,7 +798,7 @@ jobs:
           echo "### Dependency Versions" >> $GITHUB_STEP_SUMMARY
           echo "- **wizard:** $WIZARD_REF" >> $GITHUB_STEP_SUMMARY
           echo "- **context-mill:** $CONTEXT_MILL_REF" >> $GITHUB_STEP_SUMMARY
-          echo "- **mcp (posthog):** $POSTHOG_REF" >> $GITHUB_STEP_SUMMARY
+          echo "- **mcp:** prod (mcp.posthog.com)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ -n "$PR_URL" ]; then
             echo "**PR:** $PR_URL" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
Removes the posthog-master MCP server from wizard-ci and points the wizard at prod mcp.posthog.com instead.

The local server was a protocol proxy to the same us.posthog.com APIs (same phx key), but built from posthog master per run — so CI inherited master's breakages: this week's hard Redis dependency (services/mcp hono exits without redis:6379, from PostHog/posthog#72223), last cycle's 113-project cold install compiling node-rdkafka. Deleting the dependency removes both incident classes structurally: no posthog clone, no filtered pnpm install, no Redis, no :8787 readiness gate. context-mill stays local — it is the content under test. CI now exercises exactly the MCP every real user hits.

Depends on PostHog/wizard#975 (MCP_URL override wins under --local-mcp) being on the wizard ref under test — merge that first. Supersedes #3056 (the Redis stopgap): land that only if this needs to wait.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*