### PR TITLE
fix(ci): concurrency group cancels the previous fleet on re-trigger

### DIFF
--- a/.github/workflows/wizard-ci.yml
+++ b/.github/workflows/wizard-ci.yml
@@ -63,6 +63,13 @@ on:
   repository_dispatch:
     types: [wizard-ci-trigger]
 
+# One fleet per source ref: a re-trigger for the same wizard/context-mill ref
+# cancels the previous mid-flight fleet instead of stacking beside it. Manual
+# dispatches with no refs fall back to the run id (never self-grouped).
+concurrency:
+  group: wizard-ci-${{ github.event.client_payload.source || 'manual' }}-${{ github.event.client_payload.wizard_ref || inputs.wizard_ref || github.run_id }}-${{ github.event.client_payload.context_mill_ref || inputs.context_mill_ref || '' }}
+  cancel-in-progress: true
+
 jobs:
   # ============================================================================
   # DISCOVER: Find and select apps to run


### PR DESCRIPTION
wizard-ci had no concurrency config: every trigger (push to a wizard PR, comment, manual dispatch) started a fresh 40-cell fleet next to the running one, and stopping work mid-flight meant finding and cancelling each run by hand.

Adds a workflow-level concurrency group keyed on trigger source + wizard ref + context-mill ref with cancel-in-progress: re-triggering the same ref cancels the previous fleet automatically. Manual dispatches without refs key on the run id, so unrelated runs never cancel each other.

Stopping a fleet by hand stays one command: `gh run list -R PostHog/wizard-workbench -w wizard-ci.yml --status in_progress` then `gh run cancel <id> -R PostHog/wizard-workbench` — cancellation tears down every matrix cell including mid-flight agents.

---
*Created with [PostHog Code](https://posthog.com/code?ref=pr)*